### PR TITLE
fix: Linux GitHub Actions 빌드 의존성 설치 안정화

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-22.04
+          - platform: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             name: linux
           - platform: windows-latest
@@ -50,9 +50,19 @@ jobs:
         if: matrix.name == 'linux'
         run: |
           sudo apt-get update
+          WEBKIT_DEV="libwebkit2gtk-4.1-dev"
+          if ! apt-cache show "$WEBKIT_DEV" >/dev/null 2>&1; then
+            WEBKIT_DEV="libwebkit2gtk-4.0-dev"
+          fi
+
+          SOUP_DEV="libsoup-3.0-dev"
+          if ! apt-cache show "$SOUP_DEV" >/dev/null 2>&1; then
+            SOUP_DEV="libsoup2.4-dev"
+          fi
+
           sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
+            "$WEBKIT_DEV" \
+            "$SOUP_DEV" \
             librsvg2-dev \
             patchelf \
             libssl-dev \


### PR DESCRIPTION
### Motivation
- GitHub Actions의 Linux 러너 이미지 차이로 인해 `apt-get install` 단계에서 패키지 이름/버전 불일치로 빌드가 실패하는 문제가 있었습니다.
- 러너별로 사용 가능한 패키지를 감지해 올바른 패키지를 설치하도록 하여 빌드 안정성을 높이기 위함입니다.

### Description
- 빌드 매트릭스의 Linux 러너를 `ubuntu-22.04`에서 `ubuntu-24.04`로 업데이트했습니다.
- Linux 의존성 설치 단계에서 `libwebkit2gtk`와 `libsoup` 패키지를 환경에서 사용 가능한 이름으로 감지해 설치하도록 `WEBKIT_DEV`/`SOUP_DEV` fallback 로직을 추가했습니다 (예: `libwebkit2gtk-4.1-dev` → `libwebkit2gtk-4.0-dev`, `libsoup-3.0-dev` → `libsoup2.4-dev`).
- 더 이상 `libappindicator3-dev`를 설치하지 않고 기존의 `libayatana-appindicator3-dev` 설치를 유지하도록 정리했습니다.

### Testing
- 워크플로 파일 내용을 확인하기 위해 `sed -n '1,220p' .github/workflows/build-release.yml`을 실행해 변경된 블록이 반영된 것을 검증했고 성공했습니다.
- 변경사항이 반영된 파일의 라인 번호를 확인하기 위해 `nl -ba .github/workflows/build-release.yml | sed -n '20,110p'`을 실행했고 성공했습니다.
- 저장소 상태 및 변경 diff를 확인하기 위해 `git diff --check && git status --short`를 실행했고 문제가 없음을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69901bfba5148324b6fc61afc39d93f5)