### PR TITLE
다운로드 매니저: 슬롯 언더플로우 방지 및 progress/stderr 버퍼링 개선

### DIFF
--- a/src-tauri/src/ytdlp/download.rs
+++ b/src-tauri/src/ytdlp/download.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tauri::ipc::Channel;
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -58,7 +59,11 @@ impl DownloadManager {
     }
 
     pub fn release(&self) {
-        self.active_count.fetch_sub(1, Ordering::SeqCst);
+        let _ = self
+            .active_count
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                Some(count.saturating_sub(1))
+            });
     }
 
     // 1-2: Cancel support methods
@@ -306,9 +311,26 @@ async fn execute_download(app: AppHandle, task_id: u64) {
     let stdout_handle = tokio::spawn(async move {
         let reader = BufReader::new(stdout);
         let mut lines = reader.lines();
+        let mut last_progress_percent: Option<f32> = None;
+        let mut last_progress_update = tokio::time::Instant::now() - Duration::from_secs(1);
 
         while let Ok(Some(line)) = lines.next_line().await {
             if let Some(progress_info) = progress::parse_progress_line(&line) {
+                let now = tokio::time::Instant::now();
+                let should_update = match last_progress_percent {
+                    None => true,
+                    Some(prev) => {
+                        (progress_info.percent - prev).abs() >= 0.2
+                            || now.duration_since(last_progress_update)
+                                >= Duration::from_millis(500)
+                            || progress_info.percent >= 100.0
+                    }
+                };
+
+                if !should_update {
+                    continue;
+                }
+
                 let speed = progress_info.speed.as_deref().unwrap_or("...").to_string();
                 let eta = progress_info.eta.as_deref().unwrap_or("...").to_string();
 
@@ -334,6 +356,9 @@ async fn execute_download(app: AppHandle, task_id: u64) {
                     Some(&speed),
                     Some(&eta),
                 );
+
+                last_progress_percent = Some(progress_info.percent);
+                last_progress_update = now;
             }
         }
     });
@@ -343,11 +368,22 @@ async fn execute_download(app: AppHandle, task_id: u64) {
         let reader = BufReader::new(stderr);
         let mut lines = reader.lines();
         let mut output = String::new();
+        const MAX_STDERR_BUFFER: usize = 64 * 1024;
+
         while let Ok(Some(line)) = lines.next_line().await {
             if !output.is_empty() {
                 output.push('\n');
             }
             output.push_str(&line);
+
+            if output.len() > MAX_STDERR_BUFFER {
+                let truncate_from = output.len() - MAX_STDERR_BUFFER;
+                let safe_start = output
+                    .char_indices()
+                    .find_map(|(idx, _)| (idx >= truncate_from).then_some(idx))
+                    .unwrap_or(0);
+                output.drain(..safe_start);
+            }
         }
         output
     });


### PR DESCRIPTION
### Motivation
- `active_count`가 0일 때 기존 `fetch_sub`로 언더플로우가 발생하면 다운로드 큐가 비정상 동작할 수 있어 안전한 감소 로직이 필요했습니다.
- yt-dlp의 stdout으로부터 파싱된 진행률을 과도하게 이벤트/DB로 쏘면 CPU·IO 부하가 커질 수 있어 스로틀링이 필요했습니다.
- stderr를 무제한으로 누적하면 장시간 오류 상황에서 메모리 사용량이 증가할 수 있어 버퍼 상한이 필요했습니다.

### Description
- `DownloadManager::release()`에서 `fetch_sub`를 제거하고 `fetch_update(... saturating_sub)`를 사용해 0에서 언더플로우가 발생하지 않도록 수정했습니다.
- stdout 진행률 처리부에 `last_progress_percent`와 `last_progress_update`를 도입해 퍼센트 변화량(`0.2%`) 또는 시간 경과(`500ms`) 기준으로 이벤트/DB 업데이트를 스로틀링하며, `100.0`%는 즉시 반영하도록 유지했습니다.
- stderr 수집 버퍼를 최대 `64 * 1024` 바이트로 제한하고 초과 시 오래된 부분을 잘라내는 방식으로 메모리 증가를 방지하도록 변경했습니다.
- 관련으로 `std::time::Duration`와 `tokio::time::Instant`를 사용하도록 필요한 임포트를 추가했습니다.

### Testing
- `cd src-tauri && cargo test -q`를 실행했으며, 빌드 환경에 필요한 시스템 라이브러리 `glib-2.0`(pkg-config)가 없어 테스트는 실패했습니다 (환경적 제약).
- 변경 파일에 대해 `rustfmt --edition 2021 src/ytdlp/download.rs`를 실행해 포맷을 적용했고 해당 포맷 작업은 성공했습니다.
- (수정은 백엔드 다운로드 경로인 `src-tauri/src/ytdlp/download.rs`에 국한되어 있습니다.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699058a6a86c8324886ede1b1722ae64)