### PR TITLE
style: ytdlp 화면 비주얼 완성도 개선

### DIFF
--- a/src/routes/tools/ytdlp/+layout.svelte
+++ b/src/routes/tools/ytdlp/+layout.svelte
@@ -237,9 +237,9 @@
 
 <svelte:window onkeydown={handleDebugKey} />
 
-<div class="flex flex-col h-screen overflow-hidden bg-yt-bg">
+<div class="ytdlp-shell flex flex-col h-screen overflow-hidden bg-yt-bg">
   <!-- Top Header Bar -->
-  <header class="h-12 bg-yt-surface border-b border-white/[0.06] flex items-center justify-between px-5 shrink-0 z-30">
+  <header class="h-12 bg-yt-surface/85 backdrop-blur-md border-b border-white/[0.08] flex items-center justify-between px-5 shrink-0 z-30">
     <!-- Left: Logo -->
     <a href="/tools/ytdlp" class="flex items-center gap-3 hover:opacity-80 transition-opacity">
       <div class="w-7 h-7 rounded-lg bg-yt-primary flex items-center justify-center text-white shrink-0">
@@ -395,7 +395,7 @@
     ></button>
 
     <!-- Floating Popup -->
-    <div class="fixed top-12 right-4 w-96 max-h-[70vh] bg-yt-surface rounded-xl shadow-2xl shadow-black/40 z-50 flex flex-col border border-white/[0.06] animate-popup-in">
+    <div class="fixed top-12 right-4 w-96 max-h-[70vh] bg-yt-surface/95 backdrop-blur-xl rounded-xl shadow-2xl shadow-black/50 z-50 flex flex-col border border-white/[0.08] animate-popup-in">
       <!-- Header -->
       <div class="px-4 py-3 border-b border-white/[0.06] flex items-center justify-between shrink-0">
         <h3 class="font-display font-semibold text-sm text-gray-100">{t("nav.queue")}</h3>
@@ -551,4 +551,11 @@
   :global(.animate-queue-bounce) {
     animation: queue-bounce 0.6s ease-in-out;
   }
+
+  :global(.ytdlp-shell) {
+    background-image:
+      radial-gradient(circle at 10% -10%, color-mix(in srgb, var(--color-yt-primary) 18%, transparent) 0%, transparent 40%),
+      radial-gradient(circle at 90% 0%, rgba(255,255,255,0.05) 0%, transparent 36%);
+  }
+
 </style>

--- a/src/routes/tools/ytdlp/+page.svelte
+++ b/src/routes/tools/ytdlp/+page.svelte
@@ -571,11 +571,11 @@
   }
 </script>
 
-<div class="h-full overflow-y-auto hide-scrollbar">
-    <div class="px-5 py-3 pb-5 space-y-3">
+<div class="h-full overflow-y-auto hide-scrollbar ytdlp-download-page">
+    <div class="px-5 py-4 pb-6 space-y-3">
       <!-- Error -->
       {#if error}
-        <div class="bg-red-500/10 rounded-lg px-4 py-2 flex items-center justify-between">
+        <div class="bg-red-500/10 rounded-xl px-4 py-2.5 flex items-center justify-between border border-red-500/20">
           <span class="text-red-400 text-xs">{error}</span>
           <button class="text-red-400 hover:text-red-500" onclick={() => error = null}>
             <span class="material-symbols-outlined text-[18px]">close</span>
@@ -585,7 +585,7 @@
 
       <!-- Duplicate Warning -->
       {#if duplicateCheck}
-        <div class="bg-amber-500/10 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
+        <div class="bg-amber-500/10 rounded-xl px-4 py-3 flex items-center justify-between gap-3 border border-amber-500/20">
           <div class="flex items-center gap-2 min-w-0">
             <span class="material-symbols-outlined text-amber-400 text-[20px] shrink-0">warning</span>
             <span class="text-amber-400 text-xs truncate">
@@ -607,7 +607,7 @@
 
       <!-- Analyzing Indicator -->
       {#if analyzing}
-        <div class="bg-blue-500/10 rounded-lg px-4 py-2 flex items-center justify-between">
+        <div class="bg-blue-500/10 rounded-xl px-4 py-2.5 flex items-center justify-between border border-blue-500/20">
           <div class="flex items-center gap-2">
             <span class="material-symbols-outlined text-blue-500 text-[18px] animate-spin">progress_activity</span>
             <span class="text-blue-400 text-xs font-medium">
@@ -628,7 +628,7 @@
             <span class="material-symbols-outlined text-[20px]">link</span>
           </div>
           <input
-            class="w-full h-10 bg-yt-surface text-gray-100 rounded-lg pl-11 pr-4 border border-white/[0.06] focus:ring-2 focus:ring-yt-primary focus:outline-none placeholder-gray-600 font-mono text-sm"
+            class="w-full h-11 bg-yt-surface/90 text-gray-100 rounded-xl pl-11 pr-4 border border-white/[0.08] focus:ring-2 focus:ring-yt-primary/70 focus:outline-none placeholder-gray-600 font-mono text-sm shadow-[0_8px_24px_rgba(0,0,0,0.22)] transition-all"
             placeholder={t("download.urlPlaceholder")}
             type="text"
             bind:value={url}
@@ -637,7 +637,7 @@
           />
         </div>
         <button
-          class="h-10 px-5 rounded-lg shrink-0 bg-yt-primary hover:bg-blue-500 text-white font-bold flex items-center gap-2 transition-all disabled:opacity-50 text-sm"
+          class="h-11 px-5 rounded-xl shrink-0 bg-yt-primary hover:brightness-110 text-white font-bold flex items-center gap-2 transition-all disabled:opacity-50 text-sm shadow-[0_10px_24px_color-mix(in_srgb,var(--color-yt-primary)_35%,transparent)]"
           onclick={playlistResult && !videoInfo
             ? (selectedEntries.size > 0 ? handleDownloadSelected : handleDownloadAll)
             : handleStartDownload}
@@ -682,7 +682,7 @@
 
       <!-- Playlist / Channel Result -->
       {#if playlistResult}
-        <div class="border border-white/[0.06] rounded-lg overflow-hidden">
+        <div class="border border-white/[0.08] rounded-xl overflow-hidden bg-yt-surface/30 backdrop-blur-sm shadow-[0_14px_34px_rgba(0,0,0,0.22)]">
           <!-- Playlist Header -->
           <div class="px-3 py-3 border-b border-white/[0.04]">
             <div class="flex items-center gap-3">
@@ -985,4 +985,10 @@
     opacity: 1;
     transition-delay: 0.5s;
   }
+
+  :global(.ytdlp-download-page) {
+    background-image:
+      linear-gradient(180deg, rgba(255,255,255,0.02), transparent 220px);
+  }
+
 </style>


### PR DESCRIPTION
### Motivation
- ytdlp 도구 화면의 시각적 깊이감과 정보 계층을 개선해 주요 액션(입력, 다운로드, 플레이리스트)의 가독성과 사용성을 높이기 위함입니다.

### Description
- 루트 레이아웃에 `ytdlp-shell` 클래스를 추가하고 라디얼 글로우 배경을 적용해 전체적인 깊이감을 강화했습니다 (`src/routes/tools/ytdlp/+layout.svelte`).
- 상단 헤더와 다운로드 큐 팝업에 반투명·블러(`backdrop-blur-*`)와 경계선 대비를 적용해 유리 질감 같은 스타일을 적용했습니다 (`src/routes/tools/ytdlp/+layout.svelte`).
- 다운로드 페이지의 주요 UI(오류/중복/분석 배너, URL 입력창, 다운로드 버튼, 플레이리스트 카드)에 라운딩/보더/섀도우/높이 조정을 적용해 시각적 계층을 명확히 했습니다 (`src/routes/tools/ytdlp/+page.svelte`).
- 메인 스크롤 영역에 상단 선형 그라디언트 오버레이(`ytdlp-download-page`)를 추가해 콘텐츠 가독성을 보완했습니다 (`src/routes/tools/ytdlp/+page.svelte`).

### Testing
- `npm run check` 실행하여 `svelte-check` 진단을 통과했으며 결과는 오류/경고 없음으로 확인되었습니다.
- 개발 서버를 기동하기 위해 `npm run dev -- --host 0.0.0.0 --port 4173`를 실행하여 정상적으로 서버가 시작됨을 확인했습니다.
- 브라우저 자동화(Playwright)를 사용해 `/tools/ytdlp` 페이지에서 스크린샷을 캡처하여 변경 시각 결과를 검증했습니다 (스크린샷 생성 성공).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69905d39336083248cb8249227db7e3f)