### PR TITLE
feat: 다운로드 URL 입력 UX 및 가이드 시인성 개선

### DIFF
--- a/src/routes/tools/ytdlp/+page.svelte
+++ b/src/routes/tools/ytdlp/+page.svelte
@@ -555,6 +555,15 @@
     if (e.key === "Enter" && !downloading) handleAnalyze()
   }
 
+  function handleClearInput() {
+    url = ""
+    error = null
+    videoInfo = null
+    playlistResult = null
+    selectedEntries = new Set()
+    noMoreEntries = false
+  }
+
   function formatDuration(seconds: number): string {
     const m = Math.floor(seconds / 60)
     const s = seconds % 60
@@ -622,39 +631,65 @@
       {/if}
 
       <!-- URL Input -->
-      <div class="flex flex-row gap-2">
-        <div class="flex-1 relative group">
-          <div class="absolute inset-y-0 left-4 flex items-center pointer-events-none text-gray-500 group-focus-within:text-yt-primary transition-colors">
-            <span class="material-symbols-outlined text-[20px]">link</span>
+      <div class="rounded-xl border border-white/[0.06] bg-yt-highlight/50 p-3 space-y-2">
+        <div class="flex items-center justify-between">
+          <p class="text-[11px] uppercase tracking-wider text-gray-500">{t("download.urlPlaceholder")}</p>
+          <div class="flex items-center gap-1">
+            <button
+              class="px-2 py-1 rounded-md text-xs text-gray-400 hover:text-gray-100 hover:bg-white/[0.06] transition-colors"
+              onclick={handleAnalyze}
+              disabled={analyzing || downloading || !url.trim()}
+            >분석</button>
+            <button
+              class="px-2 py-1 rounded-md text-xs text-gray-400 hover:text-gray-100 hover:bg-white/[0.06] transition-colors"
+              onclick={handleClearInput}
+              disabled={analyzing || downloading || downloadingAll}
+            >초기화</button>
           </div>
-          <input
-            class="w-full h-10 bg-yt-surface text-gray-100 rounded-lg pl-11 pr-4 border border-white/[0.06] focus:ring-2 focus:ring-yt-primary focus:outline-none placeholder-gray-600 font-mono text-sm"
-            placeholder={t("download.urlPlaceholder")}
-            type="text"
-            bind:value={url}
-            onkeydown={handleKeydown}
-            disabled={downloading}
-          />
         </div>
-        <button
-          class="h-10 px-5 rounded-lg shrink-0 bg-yt-primary hover:bg-blue-500 text-white font-bold flex items-center gap-2 transition-all disabled:opacity-50 text-sm"
-          onclick={playlistResult && !videoInfo
-            ? (selectedEntries.size > 0 ? handleDownloadSelected : handleDownloadAll)
-            : handleStartDownload}
-          disabled={downloading || downloadingAll || (!videoInfo && !playlistResult && !url.trim())}
-        >
-          <span class="material-symbols-outlined text-[18px]">download</span>
-          {#if downloadingAll}
-            <span>{t("download.queuing")} ({batchProgress.current}/{batchProgress.total})</span>
-          {:else if playlistResult && !videoInfo && selectedEntries.size > 0}
-            <span>{t("download.downloadSelected")} ({selectedEntries.size})</span>
-          {:else if playlistResult && !videoInfo}
-            <span>{t("download.downloadAll")} ({playlistResult.videoCount ?? playlistResult.entries.length})</span>
-          {:else}
-            <span>{t("download.download")}</span>
-          {/if}
-        </button>
+
+        <div class="flex flex-row gap-2">
+          <div class="flex-1 relative group">
+            <div class="absolute inset-y-0 left-4 flex items-center pointer-events-none text-gray-500 group-focus-within:text-yt-primary transition-colors">
+              <span class="material-symbols-outlined text-[20px]">link</span>
+            </div>
+            <input
+              class="w-full h-10 bg-yt-surface text-gray-100 rounded-lg pl-11 pr-4 border border-white/[0.06] focus:ring-2 focus:ring-yt-primary focus:outline-none placeholder-gray-600 font-mono text-sm"
+              placeholder={t("download.urlPlaceholder")}
+              type="text"
+              bind:value={url}
+              onkeydown={handleKeydown}
+              disabled={downloading}
+            />
+          </div>
+          <button
+            class="h-10 px-5 rounded-lg shrink-0 bg-yt-primary hover:bg-blue-500 text-white font-bold flex items-center gap-2 transition-all disabled:opacity-50 text-sm"
+            onclick={playlistResult && !videoInfo
+              ? (selectedEntries.size > 0 ? handleDownloadSelected : handleDownloadAll)
+              : handleStartDownload}
+            disabled={downloading || downloadingAll || (!videoInfo && !playlistResult && !url.trim())}
+          >
+            <span class="material-symbols-outlined text-[18px]">download</span>
+            {#if downloadingAll}
+              <span>{t("download.queuing")} ({batchProgress.current}/{batchProgress.total})</span>
+            {:else if playlistResult && !videoInfo && selectedEntries.size > 0}
+              <span>{t("download.downloadSelected")} ({selectedEntries.size})</span>
+            {:else if playlistResult && !videoInfo}
+              <span>{t("download.downloadAll")} ({playlistResult.videoCount ?? playlistResult.entries.length})</span>
+            {:else}
+              <span>{t("download.download")}</span>
+            {/if}
+          </button>
+        </div>
       </div>
+
+      {#if !videoInfo && !playlistResult && !analyzing && !error}
+        <div class="rounded-xl border border-dashed border-white/[0.1] bg-white/[0.02] px-4 py-5 text-center">
+          <span class="material-symbols-outlined text-[24px] text-yt-primary">tips_and_updates</span>
+          <p class="text-sm text-gray-100 mt-1">URL을 입력하면 자동으로 분석이 시작됩니다.</p>
+          <p class="text-xs text-gray-500 mt-1">재생목록인 경우 전체/선택 다운로드를 바로 큐에 추가할 수 있습니다.</p>
+        </div>
+      {/if}
 
       <!-- Video Info Banner (after analyze) -->
       {#if videoInfo}


### PR DESCRIPTION
### Motivation
- URL 입력 → 분석 → 다운로드 흐름의 가독성과 반복 작업 동선을 줄여 초회 사용성과 재사용성을 개선하기 위함입니다.

### Description
- URL 입력 영역을 카드형 섹션으로 재구성하고 상단에 `분석` / `초기화` 보조 액션을 추가해 입력 관련 컨트롤을 한눈에 모았습니다.
- `handleClearInput` 함수를 추가해 `url`, `error`, `videoInfo`, `playlistResult`, `selectedEntries`, `noMoreEntries` 상태를 일괄 초기화하도록 구현했습니다.
- 입력창과 다운로드 버튼 레이아웃을 정리하고, 결과/오류가 없는 초기 상태에서 자동 분석 안내 카드를 노출해 초회 안내를 강화했습니다.
- 변경 파일: `src/routes/tools/ytdlp/+page.svelte`.

### Testing
- `npm run check` (Svelte diagnostics via `svelte-check`) 실행 결과 오류/경고 없음으로 성공했습니다.
- 개발 서버를 `npm run dev -- --host 0.0.0.0 --port 4173`로 실행하고 Playwright로 `/tools/ytdlp` 페이지 스크린샷을 캡처해 UI 반영을 확인했습니다 (성공). 
- 위 자동화 검사에서 실패 항목은 없었습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69905d39336083248cb8249227db7e3f)