### PR TITLE
fix: tauri-specta 바인딩에서 Channel import를 타입 전용으로 변경

### DIFF
--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -231,7 +231,7 @@ export type VideoInfo = { url: string; videoId: string; title: string; thumbnail
 
 import {
 	invoke as TAURI_INVOKE,
-	Channel as TAURI_CHANNEL,
+	type Channel as TAURI_CHANNEL,
 } from "@tauri-apps/api/core";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
 import { type WebviewWindow as __WebviewWindow__ } from "@tauri-apps/api/webviewWindow";


### PR DESCRIPTION
### Motivation
- 자동 생성된 바인딩(`src/lib/bindings.ts`)이 런타임 값으로 `Channel`을 import 하면서 `vite build` 시 `Channel is imported ... but never used` 경고를 발생시켜 빌드 로그 오염 및 경고 기반 품질 게이트 실패 가능성이 있어 이를 제거해야 했습니다.

### Description
- `src/lib/bindings.ts`에서 `Channel` 값을 import 하던 부분을 타입 전용 import로 변경하여 `type Channel as TAURI_CHANNEL`로 수정했습니다 (바인딩 파일의 불필요한 런타임 의존 제거).

### Testing
- `bun run check` 및 `bun run build`를 실행했으며 두 검사 모두 통과했고, `cd src-tauri && cargo check`는 호스트 환경에 `glib-2.0` 시스템 라이브러리가 없어 로컬에서 검증할 수 없었습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69905d4986f48324b1d6dfe9ee69fb40)