### PR TITLE
a11y: 접근성 레이블·경고색 대비 + 파괴적 동작 확인 대화상자

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -19,7 +19,8 @@
   /* Semantic status colors */
   --color-yt-success: #34c759;
   --color-yt-error: #ff3b30;
-  --color-yt-warning: #ffcc00;
+  /* amber-700: 4.5:1+ on light surfaces (WCAG AA) as foreground text and behind white. */
+  --color-yt-warning: #b45309;
 
   /* Overlay/surface colors */
   --color-yt-overlay-subtle: rgba(0, 0, 0, 0.02);
@@ -108,6 +109,10 @@ html[data-theme="dark"] {
   --color-yt-overlay-subtle: rgba(255, 255, 255, 0.03);
   --color-yt-overlay: rgba(255, 255, 255, 0.06);
   --color-yt-overlay-strong: rgba(255, 255, 255, 0.1);
+
+  /* Keep bright amber on dark bg; the light default (#b45309) is too dark here.
+     This also covers data-theme="dark" when the OS is in light mode. */
+  --color-yt-warning: #ffd60a;
 }
 
 /* Force Red Theme override */
@@ -147,6 +152,7 @@ html[data-theme="light"] {
   --color-yt-text: #1a1a1a;
   --color-yt-text-secondary: #6b7280;
   --color-yt-border: #e5e7eb;
+  --color-yt-warning: #b45309;
 }
 
 .hide-scrollbar::-webkit-scrollbar {

--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -204,6 +204,10 @@ const de: Record<string, string> = {
   "logs.cleared": "Protokolle gelöscht",
   "logs.allLevels": "Alle",
   "logs.allCategories": "Alle",
+  // Confirmations (destructive actions)
+  "queue.cancelAllConfirm": "Alle aktiven und ausstehenden Downloads abbrechen?",
+  "queue.clearCompletedConfirm": "Alle abgeschlossenen Einträge löschen?",
+  "layout.stopAllConfirm": "Alle aktiven und ausstehenden Downloads stoppen?",
 }
 
 export default de

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -212,6 +212,10 @@ const en: Record<string, string> = {
   "logs.cleared": "Logs cleared",
   "logs.allLevels": "All",
   "logs.allCategories": "All",
+  // Confirmations (destructive actions)
+  "queue.cancelAllConfirm": "Cancel all active and pending downloads?",
+  "queue.clearCompletedConfirm": "Clear all completed entries?",
+  "layout.stopAllConfirm": "Stop all active and pending downloads?",
 }
 
 export default en

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -204,6 +204,10 @@ const fr: Record<string, string> = {
   "logs.cleared": "Journaux effacés",
   "logs.allLevels": "Tous",
   "logs.allCategories": "Toutes",
+  // Confirmations (destructive actions)
+  "queue.cancelAllConfirm": "Annuler tous les téléchargements actifs et en attente ?",
+  "queue.clearCompletedConfirm": "Effacer toutes les entrées terminées ?",
+  "layout.stopAllConfirm": "Arrêter tous les téléchargements actifs et en attente ?",
 }
 
 export default fr

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -204,6 +204,10 @@ const ja: Record<string, string> = {
   "logs.cleared": "ログが削除されました",
   "logs.allLevels": "すべて",
   "logs.allCategories": "すべて",
+  // Confirmations (destructive actions)
+  "queue.cancelAllConfirm": "実行中・待機中のダウンロードをすべてキャンセルしますか？",
+  "queue.clearCompletedConfirm": "完了した項目をすべて削除しますか？",
+  "layout.stopAllConfirm": "実行中・待機中のダウンロードをすべて停止しますか？",
 }
 
 export default ja

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -204,6 +204,10 @@ const ko: Record<string, string> = {
   "logs.cleared": "로그가 삭제되었습니다",
   "logs.allLevels": "전체",
   "logs.allCategories": "전체",
+  // Confirmations (destructive actions)
+  "queue.cancelAllConfirm": "진행 중·대기 중인 다운로드를 모두 취소할까요?",
+  "queue.clearCompletedConfirm": "완료된 항목을 모두 지울까요?",
+  "layout.stopAllConfirm": "진행 중·대기 중인 다운로드를 모두 중지할까요?",
 }
 
 export default ko

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -204,6 +204,10 @@ const zhCN: Record<string, string> = {
   "logs.cleared": "日志已清除",
   "logs.allLevels": "全部",
   "logs.allCategories": "全部",
+  // Confirmations (destructive actions)
+  "queue.cancelAllConfirm": "取消所有进行中和等待中的下载？",
+  "queue.clearCompletedConfirm": "清除所有已完成的条目？",
+  "layout.stopAllConfirm": "停止所有进行中和等待中的下载？",
 }
 
 export default zhCN

--- a/src/lib/i18n/locales/zh-TW.ts
+++ b/src/lib/i18n/locales/zh-TW.ts
@@ -204,6 +204,10 @@ const zhTW: Record<string, string> = {
   "logs.cleared": "日誌已清除",
   "logs.allLevels": "全部",
   "logs.allCategories": "全部",
+  // Confirmations (destructive actions)
+  "queue.cancelAllConfirm": "取消所有進行中和等待中的下載？",
+  "queue.clearCompletedConfirm": "清除所有已完成的項目？",
+  "layout.stopAllConfirm": "停止所有進行中和等待中的下載？",
 }
 
 export default zhTW

--- a/src/routes/tools/ytdlp/+layout.svelte
+++ b/src/routes/tools/ytdlp/+layout.svelte
@@ -167,6 +167,7 @@
   }
 
   async function handleCancelAll() {
+    if (!confirm(t("layout.stopAllConfirm"))) return
     try {
       const result = await commands.cancelAllDownloads()
       if (result.status === "ok") {
@@ -617,9 +618,10 @@
       {#each navItems as item}
         <a
           href={item.href}
+          aria-current={isActive(item.href, item.exact) ? "page" : undefined}
           class="flex items-center gap-3 px-3 py-2 rounded-md transition-colors text-sm font-medium relative
-            {isActive(item.href, item.exact) 
-              ? 'bg-yt-highlight text-yt-text shadow-sm ring-1 ring-inset ring-yt-border' 
+            {isActive(item.href, item.exact)
+              ? 'bg-yt-highlight text-yt-text shadow-sm ring-1 ring-inset ring-yt-border'
               : 'text-yt-text-secondary hover:bg-yt-overlay hover:text-yt-text'}"
         >
           <span class="material-symbols-outlined text-[20px] {isActive(item.href, item.exact) ? 'text-yt-primary' : ''}">{item.icon}</span>

--- a/src/routes/tools/ytdlp/+page.svelte
+++ b/src/routes/tools/ytdlp/+page.svelte
@@ -766,7 +766,7 @@
              
              <!-- Format & Quality -->
              <div class="flex items-center gap-2 shrink-0 bg-yt-bg border border-yt-border rounded px-2 py-1">
-                <select bind:value={format} class="bg-transparent border-none p-0 text-xs text-yt-text font-medium focus:ring-0 cursor-pointer w-16">
+                <select aria-label={t("download.format")} bind:value={format} class="bg-transparent border-none p-0 text-xs text-yt-text font-medium focus:ring-0 cursor-pointer w-16">
                   <option value="mp4">MP4</option>
                   <option value="mkv">MKV</option>
                   <option value="mp3">MP3</option>
@@ -778,7 +778,7 @@
                 {#if isLosslessFormat}
                   <span class="text-xs text-yt-text font-medium px-1 w-20">{t("download.lossless")}</span>
                 {:else if isAudioFormat}
-                  <select bind:value={audioQuality} class="bg-transparent border-none p-0 text-xs text-yt-text font-medium focus:ring-0 cursor-pointer w-20">
+                  <select aria-label={t("download.quality")} bind:value={audioQuality} class="bg-transparent border-none p-0 text-xs text-yt-text font-medium focus:ring-0 cursor-pointer w-20">
                     <option value="0">Best</option>
                     <option value="320K">320K</option>
                     <option value="256K">256K</option>
@@ -786,7 +786,7 @@
                     <option value="128K">128K</option>
                   </select>
                 {:else}
-                  <select bind:value={quality} class="bg-transparent border-none p-0 text-xs text-yt-text font-medium focus:ring-0 cursor-pointer w-20">
+                  <select aria-label={t("download.quality")} bind:value={quality} class="bg-transparent border-none p-0 text-xs text-yt-text font-medium focus:ring-0 cursor-pointer w-20">
                     <option value="best">Best</option>
                     <option value="1080p">1080p</option>
                     <option value="720p">720p</option>
@@ -825,6 +825,7 @@
                   onmouseleave={hideTooltip}
                 >{t("download.cookie")}</span>
                 <select
+                  aria-label={t("download.cookie")}
                   class="bg-transparent border-none p-0 text-xs text-yt-text font-medium focus:ring-0 cursor-default"
                   bind:value={cookieBrowser}
                   onchange={() => autoSaveSettings({ cookieBrowser })}
@@ -853,6 +854,7 @@
                 >{t("download.concurrent")}</span>
                 <input
                   type="range"
+                  aria-label={t("download.concurrent")}
                   class="flex-1 max-w-24 accent-yt-primary h-1"
                   min="1" max="10"
                   bind:value={maxConcurrent}
@@ -965,6 +967,7 @@
                        <div class="shrink-0 pl-1">
                           <input
                             type="checkbox"
+                            aria-label={entry.title || t("download.noTitle")}
                             checked={selectedEntries.has(entry.videoId)}
                             onchange={() => toggleSelect(entry.videoId)}
                             class="w-4 h-4 rounded border-yt-border text-yt-primary focus:ring-yt-primary cursor-pointer"

--- a/src/routes/tools/ytdlp/queue/+page.svelte
+++ b/src/routes/tools/ytdlp/queue/+page.svelte
@@ -49,6 +49,7 @@
   }
 
   async function handleClearCompleted() {
+    if (!confirm(t("queue.clearCompletedConfirm"))) return
     try {
       const result = await commands.clearCompleted()
       if (result.status === "ok") await loadQueue()
@@ -67,6 +68,7 @@
   }
 
   async function handleCancelAll() {
+    if (!confirm(t("queue.cancelAllConfirm"))) return
     try {
       const result = await commands.cancelAllDownloads()
       if (result.status === "ok") await loadQueue()


### PR DESCRIPTION
접근성(스크린리더/키보드/대비)과 실수 방지를 위한 UX 개선입니다.

## 경고색 WCAG AA 대비 (`app.css`)
라이트 테마의 `--color-yt-warning: #ffcc00`은 `bg-yt-warning/10` 배경 위 전경 텍스트로 **대비 1.44:1**(AA 기준 4.5:1 미달)이었고, `bg-yt-warning + text-white` 버튼도 흰 글자 대비가 부족했습니다.
- 라이트 기본값을 amber-700 `#b45309`로 변경(/10 배경 4.8:1, 흰 배경 5.02:1 — AA 통과).
- 다크 테마는 `data-theme="dark"`에 `#ffd60a`를 **명시**해, OS가 라이트일 때 어두운 amber 기본값을 상속해 다크 배경에서 안 보이게 되는 회귀를 방지.
- 다크 미디어쿼리(#ffd60a)·레드 테마(#fbbf24)는 이미 AA 통과라 그대로 둠.

## 스크린리더 레이블
- 포맷/화질/오디오 화질/쿠키 `<select>`와 동시 다운로드 `<input type=range>`에 `aria-label` 추가(기존 i18n 키 재사용 — `download.format`/`download.quality`/`download.cookie`/`download.concurrent`).
- 재생목록 항목 체크박스에 영상 제목 기반 `aria-label`(`entry.title || t("download.noTitle")`) 추가 — 기존엔 레이블 없는 체크박스였습니다.
- 사이드바 내비게이션 `<a>`에 `aria-current="page"` 추가(활성 위치를 보조기술에 전달).

## 파괴적 동작 확인 대화상자
"모두 취소"(큐/팝업), "완료 항목 지우기", "모두 중지"는 되돌릴 수 없는데 확인 없이 즉시 실행됐습니다. 기존 `history.deleteConfirm` 컨벤션과 동일하게 네이티브 `confirm()` 가드를 추가하고, 7개 로케일에 확인 문구 3개를 추가했습니다.

## 검증
`bun run check`: 0 errors / 0 warnings. i18n 키 7개 로케일 모두 193개로 동기화 확인.

> 참고: `aria-label`에 기존 `download.format`/`download.quality` 키(현재 미사용)를 재사용하므로, 별도의 "미사용 i18n 키 정리" PR에서는 이 두 키를 제거 대상에서 제외합니다.