### PR TITLE
build: 릴리스 빌드에 lint 게이트 추가 + release 프로파일 최적화

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -102,6 +102,19 @@ jobs:
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
 
+      # Gate the release build on the same lint/type checks as CI, so a broken
+      # commit landing on main (e.g. a direct push or a merge that skipped CI)
+      # can never ship in a release.
+      - name: Svelte/TypeScript check
+        run: bun run check
+
+      - name: Rust fmt & clippy
+        shell: bash
+        run: |
+          cd src-tauri
+          cargo fmt -- --check
+          cargo clippy --target ${{ matrix.target == 'universal-apple-darwin' && 'aarch64-apple-darwin' || matrix.target }} -- -D warnings
+
       - name: Set version
         shell: bash
         env:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,3 +62,12 @@ urlencoding = "2"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[profile.release]
+opt-level = "s"   # optimize for size; the app is I/O-bound, not CPU-bound
+lto = true        # cross-crate optimization shrinks the final binary
+codegen-units = 1 # better optimization (release builds are infrequent)
+strip = true      # strip symbols — Tauri's recommended bundle-size win
+# NOTE: deliberately NOT setting panic = "abort". The app relies on unwinding
+# for Mutex-poisoning recovery (db/mod.rs, download/manager.rs) and to isolate
+# per-task panics so one failed download/metadata fetch cannot crash the GUI.
+


### PR DESCRIPTION
## 1. 릴리스 빌드 lint/타입 게이트 (`build-release.yml`)
`ci.yml`은 PR/dev push에서 `bun run check` + `cargo fmt --check` + `cargo clippy -- -D warnings`를 실행하지만, `build-release.yml`(main push 시 릴리스 발행)은 이 검사 없이 곧장 `tauri build`로 갑니다. 따라서 main에 직접 push되거나 CI를 우회해 머지된 깨진 코드가 그대로 릴리스로 나갈 수 있었습니다.

`Install frontend dependencies` 직후, `Set version` 앞에 CI와 **동일한** 게이트를 추가했습니다(정적 `matrix.target`만 사용 — 신뢰 불가 입력 없음).

## 2. release 프로파일 최적화 (`Cargo.toml`)
`[profile.release]`가 없어 기본값으로 빌드되고 있었습니다. 번들 크기 축소를 위해 추가:
```toml
[profile.release]
opt-level = "s"
lto = true
codegen-units = 1
strip = true
```
**`panic = "abort"`는 의도적으로 넣지 않았습니다.** 이 앱은 Mutex 포이즌 복구(`db/mod.rs`, `download/manager.rs`의 `unwrap_or_else(|e| e.into_inner())`)와 태스크별 패닉 격리(한 다운로드/메타데이터 실패가 전체 GUI를 크래시시키지 않도록)를 위해 unwinding에 의존하므로, abort는 이 설계를 깨뜨립니다.

## 검증
- `cargo metadata`로 매니페스트/프로파일 키 유효성 확인
- 두 워크플로 YAML 파싱 정상, 추가 게이트는 현재 통과 중인 `ci.yml`과 동일
- `lto=true` release 빌드가 정상 링크되는지 별도 target에서 빌드 확인(로컬)