### PR TITLE
fix: 의존성 탭 동시 설치/업데이트 동시성 버그 수정

### DIFF
--- a/src-tauri/src/modules/log_db.rs
+++ b/src-tauri/src/modules/log_db.rs
@@ -135,7 +135,8 @@ impl LogDatabase {
         }
 
         // Data query
-        let offset = page * page_size;
+        // Widen before multiplying so a large page can't overflow u32 (matches db/queue.rs).
+        let offset = (page as u64) * (page_size as u64);
         let data_sql = format!(
             "SELECT id, timestamp, level, category, message, details FROM logs {} ORDER BY timestamp DESC, id DESC LIMIT ?{} OFFSET ?{}",
             where_clause, param_idx, param_idx + 1

--- a/src-tauri/src/ytdlp/commands/dependency.rs
+++ b/src-tauri/src/ytdlp/commands/dependency.rs
@@ -227,6 +227,10 @@ pub async fn delete_app_managed_dep(app: AppHandle, dep_name: String) -> Result<
         }
     };
 
+    // Hold the same per-dependency lock the installers use, so a delete can't run
+    // halfway through an in-flight install/update of this dependency.
+    let _lock = crate::ytdlp::dep_download::lock_dependency(&dep_name).await;
+
     let mut deleted = Vec::new();
     for name in &names_to_delete {
         let path = bin_dir.join(name);

--- a/src-tauri/src/ytdlp/db/history.rs
+++ b/src-tauri/src/ytdlp/db/history.rs
@@ -56,7 +56,8 @@ impl Database {
                 .map_err(|e| AppError::DatabaseError(e.to_string()))?
         };
 
-        let offset = page * page_size;
+        // Widen before multiplying so a large page can't overflow u32 (matches db/queue.rs).
+        let offset = (page as u64) * (page_size as u64);
         let query = format!(
             "SELECT id, video_url, video_id, title, quality_label, format, file_path, file_size, downloaded_at
              FROM history

--- a/src-tauri/src/ytdlp/dep_deno.rs
+++ b/src-tauri/src/ytdlp/dep_deno.rs
@@ -34,6 +34,9 @@ fn get_binary_name() -> &'static str {
 
 /// Install deno by downloading from GitHub releases.
 pub async fn install_deno(app: &AppHandle) -> Result<String, AppError> {
+    // Serialize against any concurrent deno install/update/delete so they don't
+    // corrupt the shared archive temp file or race the extracted binary.
+    let _lock = lock_dependency("deno").await;
     let bin_dir = ensure_bin_dir(app)?;
     let url = get_download_url()?;
     let binary_name = get_binary_name();

--- a/src-tauri/src/ytdlp/dep_download.rs
+++ b/src-tauri/src/ytdlp/dep_download.rs
@@ -2,8 +2,33 @@ use super::types::{DepInstallEvent, DepInstallStage};
 use crate::modules::types::AppError;
 use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex as StdMutex};
 use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+/// Per-dependency install/update/delete locks.
+///
+/// Every operation on a single dependency shares one fixed temp file name and
+/// one final binary path, so two running at once would truncate each other's
+/// in-flight download/extraction or race finalize-vs-delete. Serializing per
+/// dependency closes that hole while still letting different dependencies (which
+/// use different paths) install in parallel.
+static DEP_LOCKS: std::sync::LazyLock<StdMutex<HashMap<String, Arc<AsyncMutex<()>>>>> =
+    std::sync::LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+/// Acquire the lock for `dep`, serializing all filesystem-mutating work on it.
+/// Hold the returned guard for the whole install/update/delete operation.
+pub async fn lock_dependency(dep: &str) -> OwnedMutexGuard<()> {
+    let lock = {
+        let mut map = DEP_LOCKS.lock().unwrap_or_else(|e| e.into_inner());
+        map.entry(dep.to_string())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    };
+    lock.lock_owned().await
+}
 
 /// Ensure the `app_data_dir/bin/` directory exists and return its path.
 pub fn ensure_bin_dir(app: &AppHandle) -> Result<PathBuf, AppError> {
@@ -335,7 +360,13 @@ pub fn remove_quarantine(_path: &Path) -> Result<(), AppError> {
 
 /// Atomically move a temporary file to its final path.
 pub fn finalize_binary(temp_path: &Path, final_path: &Path) -> Result<(), AppError> {
-    // Remove existing binary if present
+    // Prefer a single atomic rename: on Unix it replaces the destination in one
+    // step, so there is never a window where the binary is missing and a process
+    // already running the old copy keeps its inode. Windows `rename` refuses to
+    // overwrite an existing file, so fall back to remove-then-rename there.
+    if std::fs::rename(temp_path, final_path).is_ok() {
+        return Ok(());
+    }
     if final_path.exists() {
         std::fs::remove_file(final_path).map_err(|e| {
             AppError::DependencyInstallError(format!("Failed to remove old binary: {}", e))

--- a/src-tauri/src/ytdlp/dep_ffmpeg.rs
+++ b/src-tauri/src/ytdlp/dep_ffmpeg.rs
@@ -55,6 +55,9 @@ fn get_binary_names() -> &'static [&'static str] {
 
 /// Install ffmpeg by downloading from GitHub.
 pub async fn install_ffmpeg(app: &AppHandle) -> Result<String, AppError> {
+    // Serialize against any concurrent ffmpeg install/update/delete so they don't
+    // corrupt the shared archive temp file or race the extracted binaries.
+    let _lock = lock_dependency("ffmpeg").await;
     let bin_dir = ensure_bin_dir(app)?;
     let (url, format) = get_download_info()?;
     let binary_names = get_binary_names();

--- a/src-tauri/src/ytdlp/dep_ytdlp.rs
+++ b/src-tauri/src/ytdlp/dep_ytdlp.rs
@@ -36,6 +36,9 @@ fn get_binary_name() -> &'static str {
 
 /// Install yt-dlp by downloading from GitHub releases.
 pub async fn install_ytdlp(app: &AppHandle) -> Result<String, AppError> {
+    // Serialize against any concurrent yt-dlp install/update/delete so they don't
+    // corrupt the shared temp file or race the final binary swap.
+    let _lock = lock_dependency("yt-dlp").await;
     let bin_dir = ensure_bin_dir(app)?;
     let url = get_download_url();
     let temp_name = format!("{}.tmp", get_binary_name());

--- a/src/routes/tools/ytdlp/queue/+page.svelte
+++ b/src/routes/tools/ytdlp/queue/+page.svelte
@@ -59,8 +59,9 @@
 
   async function handleCancel(id: number) {
     try {
-      await commands.cancelDownload(id)
-      await loadQueue()
+      const result = await commands.cancelDownload(id)
+      if (result.status === "ok") await loadQueue()
+      else console.error("Failed to cancel download:", Object.values(result.error)[0])
     } catch (e) {
       console.error("Failed to cancel download:", e)
     }

--- a/src/routes/tools/ytdlp/settings/dependencies/+page.svelte
+++ b/src/routes/tools/ytdlp/settings/dependencies/+page.svelte
@@ -38,28 +38,50 @@
   // Dependency management state
   let depStatus = $state<FullDependencyStatus | null>(null)
   let depLoading = $state(true)
-  let updatingDep = $state<string | null>(null)
-  let installingDep = $state<string | null>(null)
+  // Per-dependency in-flight flags so concurrent installs/updates each track and
+  // disable only their own button. A single `string | null` would re-enable the
+  // first button (and drop its spinner) the moment a second operation started.
+  let updatingDeps = $state<Record<string, boolean>>({})
+  let installingDeps = $state<Record<string, boolean>>({})
   let installingAll = $state(false)
-  let depActionResult = $state<{ dep: string, success: boolean, message: string } | null>(null)
+  // Per-dependency action result so two operations in flight at once don't clobber
+  // each other's message. The "all" key holds the Install All result.
+  let depActionResults = $state<Record<string, { success: boolean, message: string }>>({})
   let installProgress = $state<Record<string, { stage: string, percent: number, message: string | null }>>({})
   // Inline note shown when a user taps a source that isn't available for a dep.
   let sourceHint = $state<{ dep: string, message: string } | null>(null)
+  // In-flight loadDepStatus count: only stop the spinner when the last call resolves.
+  let depLoadCount = $state(0)
+
+  function setResult(dep: string, success: boolean, message: string) {
+    depActionResults = { ...depActionResults, [dep]: { success, message } }
+  }
+
+  function clearResult(dep: string) {
+    const next = { ...depActionResults }
+    delete next[dep]
+    depActionResults = next
+  }
 
   async function loadDepStatus(force = false) {
+    depLoadCount++
     depLoading = true
     try {
       const result = await commands.checkFullDependencies(force)
       if (result.status === "ok") {
         depStatus = result.data
       }
-    } catch (e) { console.error("Failed to load dep status:", e) }
-    depLoading = false
+    } catch (e) {
+      console.error("Failed to load dep status:", e)
+    } finally {
+      depLoadCount--
+      if (depLoadCount === 0) depLoading = false
+    }
   }
 
   async function handleInstallDep(depName: string) {
-    installingDep = depName
-    depActionResult = null
+    installingDeps = { ...installingDeps, [depName]: true }
+    clearResult(depName)
 
     let unlistenFn: (() => void) | null = null
     try {
@@ -85,14 +107,14 @@
     try {
       const result = await commands.installDependency(depName)
       if (result.status === "ok") {
-        depActionResult = { dep: depName, success: true, message: result.data }
+        setResult(depName, true, result.data)
       } else {
-        depActionResult = { dep: depName, success: false, message: Object.values(result.error)[0] as string }
+        setResult(depName, false, Object.values(result.error)[0] as string)
       }
     } catch (e: any) {
-      depActionResult = { dep: depName, success: false, message: e?.message || String(e) }
+      setResult(depName, false, e?.message || String(e))
     } finally {
-      installingDep = null
+      installingDeps = { ...installingDeps, [depName]: false }
       if (unlistenFn) unlistenFn()
       await loadDepStatus(true)
     }
@@ -100,7 +122,7 @@
 
   async function handleInstallAll() {
     installingAll = true
-    depActionResult = null
+    clearResult("all")
     installProgress = {}
 
     let unlistenFn: (() => void) | null = null
@@ -136,15 +158,15 @@
       if (result.status === "ok") {
         const failures = result.data.filter(r => r.includes("FAILED"))
         if (failures.length > 0) {
-          depActionResult = { dep: "all", success: false, message: failures.join("\n") }
+          setResult("all", false, failures.join("\n"))
         } else {
-          depActionResult = { dep: "all", success: true, message: t("layout.installSuccess") }
+          setResult("all", true, t("layout.installSuccess"))
         }
       } else {
-        depActionResult = { dep: "all", success: false, message: Object.values(result.error)[0] as string }
+        setResult("all", false, Object.values(result.error)[0] as string)
       }
     } catch (e: any) {
-      depActionResult = { dep: "all", success: false, message: e?.message || String(e) }
+      setResult("all", false, e?.message || String(e))
     } finally {
       installingAll = false
       if (unlistenFn) unlistenFn()
@@ -154,19 +176,19 @@
   }
 
   async function handleUpdateDep(depName: string) {
-    updatingDep = depName
-    depActionResult = null
+    updatingDeps = { ...updatingDeps, [depName]: true }
+    clearResult(depName)
     try {
       const result = await commands.updateDependency(depName)
       if (result.status === "ok") {
-        depActionResult = { dep: depName, success: true, message: result.data }
+        setResult(depName, true, result.data)
       } else {
-        depActionResult = { dep: depName, success: false, message: Object.values(result.error)[0] as string }
+        setResult(depName, false, Object.values(result.error)[0] as string)
       }
     } catch (e: any) {
-      depActionResult = { dep: depName, success: false, message: e?.message || String(e) }
+      setResult(depName, false, e?.message || String(e))
     } finally {
-      updatingDep = null
+      updatingDeps = { ...updatingDeps, [depName]: false }
       await loadDepStatus(true)
     }
   }
@@ -386,10 +408,10 @@
                   {#if !dep.info.installed}
                     <button
                       onclick={() => handleInstallDep(dep.key)}
-                      disabled={installingDep === dep.key || installingAll}
+                      disabled={installingDeps[dep.key] || installingAll}
                       class="px-3 py-1.5 text-xs font-medium bg-yt-primary hover:bg-yt-primary-hover text-white rounded-md transition-colors disabled:opacity-50 flex items-center gap-1"
                     >
-                      {#if installingDep === dep.key}
+                      {#if installingDeps[dep.key]}
                         <span class="material-symbols-outlined text-[14px] animate-spin">progress_activity</span>
                       {/if}
                       {t("settings.install")}
@@ -397,10 +419,10 @@
                   {:else if dep.info.source === "AppManaged"}
                     <button
                       onclick={() => handleUpdateDep(dep.key)}
-                      disabled={updatingDep === dep.key || installingAll}
+                      disabled={updatingDeps[dep.key] || installingAll}
                       class="px-3 py-1.5 text-xs font-medium bg-yt-highlight hover:bg-yt-border text-yt-text rounded-md transition-colors disabled:opacity-50 flex items-center gap-1"
                     >
-                      {#if updatingDep === dep.key}
+                      {#if updatingDeps[dep.key]}
                         <span class="material-symbols-outlined text-[14px] animate-spin">progress_activity</span>
                         {t("settings.updating")}
                       {:else}
@@ -412,13 +434,13 @@
               </div>
             </div>
           {/each}
-          {#if depActionResult}
-            <div class="p-3 {depActionResult.success ? 'bg-green-500/5' : 'bg-red-500/5'}">
-              <p class="text-xs {depActionResult.success ? 'text-yt-success' : 'text-red-400'}">
-                {depActionResult.dep === "all" ? "" : `${depActionResult.dep}: `}{depActionResult.message}
+          {#each Object.entries(depActionResults) as [dep, res] (dep)}
+            <div class="p-3 {res.success ? 'bg-green-500/5' : 'bg-red-500/5'}">
+              <p class="text-xs {res.success ? 'text-yt-success' : 'text-red-400'}">
+                {dep === "all" ? "" : `${dep}: `}{res.message}
               </p>
             </div>
-          {/if}
+          {/each}
         {/if}
       </div>
     </section>


### PR DESCRIPTION
## 배경

의존성 탭(`settings/dependencies`)에서 **여러 항목(yt-dlp/ffmpeg/deno)의 설치·업데이트 버튼을 거의 동시에 누르면** 바이너리가 손상되거나 UI 상태가 어긋나는 버그가 있었습니다. 다차원 코드 리뷰로 이 경로를 집중 검증해 **프론트·백엔드 양쪽의 근본 원인**을 고쳤습니다.

> 기존 열린 PR(#33~#41)과 **중복되지 않는** 영역만 담았습니다. #34는 다운로드 슬롯 회계(`DownloadManager`), #35는 의존성 바이너리 **무결성/체크섬/SSRF**를 다루지만, **의존성 설치/업데이트의 동시성(상호배제)** 은 어디서도 다루지 않았습니다.

## 수정 내역

### 🔴 백엔드 — 의존성 설치/업데이트/삭제 동시성 (핵심)

설치 파이프라인 어디에도 상호배제가 없었습니다. `install_dependency`, `install_all_dependencies`(`tokio::join!`), `update_dependency`(= `install_dependency` 별칭), `delete_app_managed_dep`가 **락 없이 동시에** 같은 의존성을 건드릴 수 있었고,

- `download_file`은 의존성마다 **고정 temp 파일명**(`yt-dlp.tmp` / `ffmpeg_archive.zip` / `deno_archive.zip`)을 공유 `bin/`에 사용 → 같은 의존성을 동시에 받으면 `File::create`의 truncate로 서로의 다운로드를 덮어써 **손상**.
- `extract_zip/tar_gz/tar_xz`는 **최종 바이너리 경로에 직접**(`File::create`, 비원자적) 추출 → 동시 추출 시 서로 truncate.
- `finalize_binary`는 `remove` 후 `rename` → 바이너리가 잠깐 사라지는 구간 + 동시 `delete`와의 경합.

**수정**
- `dep_download::lock_dependency(dep)` 도입 — 의존성별 비동기 락(`tokio::sync::Mutex`)으로 **같은 의존성의 install/update/delete를 직렬화**. 서로 다른 의존성은 경로가 달라 그대로 병렬 실행됩니다. `install_ytdlp/ffmpeg/deno`와 `delete_app_managed_dep` 진입부에서 획득.
- `finalize_binary`를 **atomic rename 우선**으로 변경 — Unix에선 단일 `rename`으로 교체(바이너리가 사라지는 구간 제거, 실행 중 프로세스는 기존 inode 유지), Windows에선 `remove` 후 `rename`로 폴백.

### 🟠 프론트 — 의존성 탭 동시 작업 상태

- `updatingDep`/`installingDep`가 **단일 `string`** 이라, yt-dlp 업데이트 중 ffmpeg를 누르면 `updatingDep`가 덮어써져 **yt-dlp 버튼이 다시 활성화되고 스피너가 사라졌습니다**(그 사이 같은 항목을 또 눌러 중복 작업 유발 가능). → **의존성별 `Record`** 로 바꿔 각 버튼이 자기 상태만 반영하고, 작업 중엔 자기 버튼만 비활성화.
- `loadDepStatus`가 진입/종료에서 `depLoading`을 무조건 토글 → 동시 호출 중 **먼저 끝난 호출이 스피너를 꺼버림**. → in-flight 카운터로 **마지막 호출이 끝날 때만** 스피너 종료.
- `depActionResult` 단일 슬롯을 동시 작업이 서로 덮어씀 → **의존성별 결과**로 분리해 각 작업 결과를 따로 표시.

### 🟡 추가 비중복 수정

- **페이지네이션 offset u32 오버플로** (`db/history.rs`, `modules/log_db.rs`): `page * page_size`를 u32로 곱해 큰 page에서 wrap(릴리스)/panic(디버그). 이미 올바른 `db/queue.rs`와 동일하게 `(page as u64) * (page_size as u64)`로 widening. (잠재 버그/일관성)
- **큐 취소 피드백** (`queue/+page.svelte`): `handleCancel`이 `cancelDownload`의 `Result`를 확인하지 않아 실패해도 무피드백 → 형제 핸들러(`handleClearCompleted`/`handleCancelAll`)와 동일하게 `status` 확인.

## 검증

- `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` (0 warning) · `cargo test` (25 passed)
- `bun run check` (0 errors / 0 warnings)
- 동작 검증은 정적/로직 기준입니다(실제 바이너리 다운로드는 비포함).

## 비고

리뷰에서 함께 확인했으나 이 PR 범위 밖이라 제외한 항목: 설정 저장 시 별도 페이지 스냅샷 간 lost-update(다중 창 전제, 영향 미미 + 스키마 변경 필요). 필요 시 후속 PR로 분리하겠습니다.
