### PR TITLE
fix: 중복 다운로드 경고에서 재다운로드 허용

### DIFF
--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -77,6 +77,7 @@ const de: Record<string, string> = {
   "download.skippedExists": "{count} Video(s) übersprungen (bereits heruntergeladen).",
   "download.cancel": "Abbrechen",
   "download.close": "Schließen",
+  "download.downloadAnyway": "Trotzdem herunterladen",
   "download.alreadyDownloaded": "\u201E{title}\u201C wurde bereits heruntergeladen.",
   "download.error": "Fehler",
   "download.duplicateFound": "Duplikat gefunden",

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -80,6 +80,7 @@ const en: Record<string, string> = {
   "download.skippedExists": "{count} video(s) skipped (already downloaded).",
   "download.cancel": "Cancel",
   "download.close": "Close",
+  "download.downloadAnyway": "Download anyway",
   "download.alreadyDownloaded": "\"{title}\" has already been downloaded.",
   "download.error": "Error",
   "download.duplicateFound": "Duplicate Found",

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -79,6 +79,7 @@ const fr: Record<string, string> = {
   "download.skippedExists": "{count} vidéo(s) ignorée(s) (déjà téléchargée(s)).",
   "download.cancel": "Annuler",
   "download.close": "Fermer",
+  "download.downloadAnyway": "Télécharger quand même",
   "download.alreadyDownloaded": "« {title} » a déjà été téléchargée.",
   "download.error": "Erreur",
   "download.duplicateFound": "Doublon trouvé",

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -77,6 +77,7 @@ const ja: Record<string, string> = {
   "download.skippedExists": "{count}件の動画がスキップされました（すでにダウンロード済み）。",
   "download.cancel": "キャンセル",
   "download.close": "閉じる",
+  "download.downloadAnyway": "それでもダウンロード",
   "download.alreadyDownloaded": "「{title}」はすでにダウンロード済みです。",
   "download.error": "エラー",
   "download.duplicateFound": "重複を検出",

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -77,6 +77,7 @@ const ko: Record<string, string> = {
   "download.skippedExists": "{count}개 영상이 이미 다운로드되어 건너뛰었습니다.",
   "download.cancel": "취소",
   "download.close": "닫기",
+  "download.downloadAnyway": "그래도 다운로드",
   "download.alreadyDownloaded": "\"{title}\"은(는) 이미 다운로드한 적이 있습니다.",
   "download.error": "오류",
   "download.duplicateFound": "중복 발견",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -79,6 +79,7 @@ const zhCN: Record<string, string> = {
   "download.skippedExists": "{count}个视频已跳过（已下载）。",
   "download.cancel": "取消",
   "download.close": "关闭",
+  "download.downloadAnyway": "仍然下载",
   "download.alreadyDownloaded": "「{title}」已经下载过。",
   "download.error": "错误",
   "download.duplicateFound": "发现重复",

--- a/src/lib/i18n/locales/zh-TW.ts
+++ b/src/lib/i18n/locales/zh-TW.ts
@@ -79,6 +79,7 @@ const zhTW: Record<string, string> = {
   "download.skippedExists": "{count}部影片已略過（已下載）。",
   "download.cancel": "取消",
   "download.close": "關閉",
+  "download.downloadAnyway": "仍然下載",
   "download.alreadyDownloaded": "「{title}」已經下載過。",
   "download.error": "錯誤",
   "download.duplicateFound": "發現重複",

--- a/src/routes/tools/ytdlp/+page.svelte
+++ b/src/routes/tools/ytdlp/+page.svelte
@@ -608,6 +608,14 @@
     pendingRequest = null
   }
 
+  async function confirmDuplicateDownload() {
+    const request = pendingRequest
+    duplicateCheck = null
+    pendingRequest = null
+    if (!request) return
+    await executeDownload(request)
+  }
+
   async function handleCancelDownload() {
     if (taskId) {
       try {
@@ -787,6 +795,10 @@
             </p>
           </div>
           <div class="flex flex-col gap-2 shrink-0">
+            <button
+              class="px-3 py-1.5 rounded-md bg-yt-primary hover:bg-yt-primary-hover text-white text-xs font-medium transition-colors"
+              onclick={confirmDuplicateDownload}
+            >{t("download.downloadAnyway")}</button>
             <button
               class="px-3 py-1.5 rounded-md bg-yt-surface hover:bg-yt-highlight border border-yt-border text-yt-text-secondary text-xs font-medium transition-colors"
               onclick={cancelDuplicate}


### PR DESCRIPTION
## 요약
- 이미 다운로드한 영상 경고에서 닫기만 가능하던 흐름에 “그래도 다운로드” 액션을 추가했습니다.
- 확인 시 저장된 pending request로 바로 큐 등록을 이어갑니다.
- 지원 locale 7개에 새 문구를 추가했습니다.

## 검증
- npm ci
- npm run check