### PR TITLE
fix: videoId 없는 큐 항목의 썸네일 요청 방지

### DIFF
--- a/src/routes/tools/ytdlp/queue/+page.svelte
+++ b/src/routes/tools/ytdlp/queue/+page.svelte
@@ -229,8 +229,9 @@
     loadHistory()
   }
 
-  function thumbUrl(videoId: string): string {
-    return `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`
+  function thumbUrl(videoId: string | null | undefined): string | null {
+    const id = videoId?.trim()
+    return id ? `https://i.ytimg.com/vi/${id}/mqdefault.jpg` : null
   }
 
   function hideThumb(e: Event) {
@@ -243,10 +244,13 @@
 </script>
 
 {#snippet activeItemCard(item: any)}
+  {@const thumbnail = thumbUrl(item.videoId)}
   <div class="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-yt-surface border border-yt-border/60" in:fade>
     <div class="relative w-16 h-10 rounded overflow-hidden bg-yt-overlay-subtle shrink-0">
       <span class="absolute inset-0 flex items-center justify-center material-symbols-outlined text-yt-text-muted text-[18px]">movie</span>
-      <img src={thumbUrl(item.videoId)} alt="" loading="lazy" class="absolute inset-0 w-full h-full object-cover" onerror={hideThumb} />
+      {#if thumbnail}
+        <img src={thumbnail} alt="" loading="lazy" class="absolute inset-0 w-full h-full object-cover" onerror={hideThumb} />
+      {/if}
       {#if item.status === "downloading"}
         <div class="absolute inset-0 bg-black/40 flex items-center justify-center">
           <span class="material-symbols-outlined text-white text-[16px] animate-spin">progress_activity</span>
@@ -302,10 +306,13 @@
 {/snippet}
 
 {#snippet historyItemCard(item: any)}
+  {@const thumbnail = thumbUrl(item.videoId)}
   <div class="group flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-yt-highlight/40 transition-colors">
     <div class="relative w-16 h-10 rounded overflow-hidden bg-yt-overlay-subtle shrink-0">
       <span class="absolute inset-0 flex items-center justify-center material-symbols-outlined text-yt-success/60 text-[18px]">check_circle</span>
-      <img src={thumbUrl(item.videoId)} alt="" loading="lazy" class="absolute inset-0 w-full h-full object-cover" onerror={hideThumb} />
+      {#if thumbnail}
+        <img src={thumbnail} alt="" loading="lazy" class="absolute inset-0 w-full h-full object-cover" onerror={hideThumb} />
+      {/if}
     </div>
     <div class="flex-1 min-w-0">
       <h4 class="font-medium text-yt-text text-sm truncate mb-0.5">{item.title}</h4>


### PR DESCRIPTION
## 요약
- 큐/기록 항목에서 videoId가 없으면 YouTube thumbnail URL을 만들지 않게 했습니다.
- ID 없는 항목은 기존 placeholder 아이콘만 보여 네트워크 잡음과 깨진 이미지 상태를 줄입니다.

## 검증
- npm ci
- npm run check