### PR TITLE
fix: 프록시 포트 범위 검증 강화

### DIFF
--- a/src-tauri/src/ytdlp/security.rs
+++ b/src-tauri/src/ytdlp/security.rs
@@ -334,6 +334,16 @@ pub fn sanitize_proxy(proxy: &str) -> Result<String, AppError> {
             "Proxy must be like http://host:port or socks5://127.0.0.1:1080".to_string(),
         ));
     }
+    let without_slash = proxy.trim_end_matches('/');
+    if let Some((_, port)) = without_slash.rsplit_once(':') {
+        if port.chars().all(|c| c.is_ascii_digit())
+            && port.parse::<u16>().ok().filter(|p| *p > 0).is_none()
+        {
+            return Err(AppError::Custom(
+                "Proxy port must be between 1 and 65535".to_string(),
+            ));
+        }
+    }
     Ok(proxy.to_string())
 }
 
@@ -493,6 +503,10 @@ mod tests {
         assert!(sanitize_proxy("http://127.0.0.1:8080").is_ok());
         assert!(sanitize_proxy("https://proxy.example.com:3128").is_ok());
         assert!(sanitize_proxy("socks5://127.0.0.1:1080").is_ok());
+        assert!(sanitize_proxy("http://proxy.example.com:65535").is_ok());
+        assert!(sanitize_proxy("http://proxy.example.com:0").is_err());
+        assert!(sanitize_proxy("http://proxy.example.com:65536").is_err());
+        assert!(sanitize_proxy("http://proxy.example.com:99999").is_err());
         assert!(sanitize_proxy("javascript:alert(1)").is_err());
         assert!(sanitize_proxy("not a url").is_err());
     }


### PR DESCRIPTION
## 요약
- 프록시 URL 검증에서 0 또는 65535 초과 포트를 거부합니다.
- 기존 형식 검증에 실제 TCP 포트 범위 확인을 추가했습니다.
- 포트 경계값 단위 테스트를 추가했습니다.

## 검증
- cargo test test_proxy