### PR TITLE
fix: 다운로드 구간 시간값 검증 강화

### DIFF
--- a/src-tauri/src/ytdlp/security.rs
+++ b/src-tauri/src/ytdlp/security.rs
@@ -309,7 +309,9 @@ pub fn sanitize_limit_rate(rate: &str) -> Result<String, AppError> {
 /// optionally prefixed with "*"). Only a single time range is accepted.
 pub fn sanitize_download_sections(sections: &str) -> Result<String, AppError> {
     let sections = sections.trim();
-    let re = regex::Regex::new(r"^\*?\d{1,2}:\d{2}(:\d{2})?-\d{1,2}:\d{2}(:\d{2})?$").unwrap();
+    let re =
+        regex::Regex::new(r"^\*?(?:\d{1,2}:)?[0-5]?\d:[0-5]\d-(?:\d{1,2}:)?[0-5]?\d:[0-5]\d$")
+            .unwrap();
     if !re.is_match(sections) {
         return Err(AppError::Custom(
             "Section must be a time range like 1:30-2:45 or 00:01:30-00:02:45".to_string(),
@@ -486,6 +488,8 @@ mod tests {
         assert!(sanitize_download_sections("*0:10-0:20").is_ok());
         assert!(sanitize_download_sections("30-90").is_err());
         assert!(sanitize_download_sections("1:30,2:45").is_err());
+        assert!(sanitize_download_sections("1:99-2:00").is_err());
+        assert!(sanitize_download_sections("1:30-2:99").is_err());
     }
 
     #[test]

--- a/src/lib/advanced.ts
+++ b/src/lib/advanced.ts
@@ -52,7 +52,7 @@ export const SUB_CONVERT_FORMATS = ["", "srt", "ass", "vtt", "lrc"] as const
 const RE = {
   subLangs: /^[A-Za-z0-9,.\-_*]+$/,
   limitRate: /^\d+(\.\d+)?[KMGkmg]?$/,
-  downloadSections: /^\*?\d{1,2}:\d{2}(:\d{2})?-\d{1,2}:\d{2}(:\d{2})?$/,
+  downloadSections: /^\*?(?:\d{1,2}:)?[0-5]?\d:[0-5]\d-(?:\d{1,2}:)?[0-5]?\d:[0-5]\d$/,
   proxy: /^(https?|socks4|socks5):\/\/[A-Za-z0-9.\-_]+(:\d{1,5})?\/?$/i,
 } as const
 


### PR DESCRIPTION
## 요약
- 다운로드 구간 입력에서 분/초가 00-59 범위를 벗어나면 거부하도록 UI/백엔드 정규식을 맞췄습니다.
- 1:99 같은 값이 yt-dlp 단계까지 넘어가 뒤늦게 실패하는 흐름을 줄입니다.
- 잘못된 분/초 케이스 단위 테스트를 추가했습니다.

## 검증
- npm ci
- npm run check
- cargo test test_download_sections