### PR TITLE
fix: 0 속도 제한 입력 차단

### DIFF
--- a/src-tauri/src/ytdlp/security.rs
+++ b/src-tauri/src/ytdlp/security.rs
@@ -302,6 +302,13 @@ pub fn sanitize_limit_rate(rate: &str) -> Result<String, AppError> {
             "Rate limit must look like 1M, 500K or 4.2M (no spaces or units like MB/s)".to_string(),
         ));
     }
+    let numeric = rate
+        .trim_end_matches(|c: char| matches!(c, 'K' | 'M' | 'G' | 'k' | 'm' | 'g'));
+    if numeric.parse::<f64>().ok().filter(|v| *v > 0.0).is_none() {
+        return Err(AppError::Custom(
+            "Rate limit must be greater than zero".to_string(),
+        ));
+    }
     Ok(rate.to_string())
 }
 
@@ -475,6 +482,9 @@ mod tests {
         assert!(sanitize_limit_rate("500K").is_ok());
         assert!(sanitize_limit_rate("4.2M").is_ok());
         assert!(sanitize_limit_rate("1000").is_ok());
+        assert!(sanitize_limit_rate("0").is_err());
+        assert!(sanitize_limit_rate("0K").is_err());
+        assert!(sanitize_limit_rate("0.0M").is_err());
         assert!(sanitize_limit_rate("1 MB/s").is_err());
         assert!(sanitize_limit_rate("fast").is_err());
     }

--- a/src/lib/advanced.ts
+++ b/src/lib/advanced.ts
@@ -63,5 +63,9 @@ export function validateAdvancedField(field: AdvancedTextField, value: string): 
   const v = value.trim()
   if (v === "") return true
   if (field === "subLangs" && v.length > 200) return false
+  if (field === "limitRate") {
+    const numeric = v.replace(/[KMGkmg]$/, "")
+    if (Number(numeric) <= 0) return false
+  }
   return RE[field].test(v)
 }


### PR DESCRIPTION
## 요약
- 속도 제한 입력에서 0, 0K, 0.0M 같은 값이 통과하지 않도록 UI와 백엔드 검증을 강화했습니다.
- 형식은 맞지만 다운로드 동작을 망가뜨릴 수 있는 무의미한 제한값을 차단합니다.
- 0 계열 값 단위 테스트를 추가했습니다.

## 검증
- npm ci
- npm run check
- cargo test test_limit_rate