### PR TITLE
Align sidecar license compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ artifacts are uploaded to R2.
 
 This app bundles or downloads the following open-source binaries:
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
-FFmpeg is licensed under the GNU General Public License v3. The exact GPL build shipped with each release is linked above, with corresponding source available from the FFmpeg project and the build providers.
+FFmpeg is licensed under the GNU General Public License v3 when the app uses the BtbN GPL builds. Windows and Linux app-managed downloads use those redistributable GPL builds. macOS FFmpeg auto-download is disabled until a redistributable GPL/LGPL build is configured; macOS users can use a system FFmpeg installation, or a release can ship a compliant bundled sidecar with matching source and build instructions.
+
+Packaged releases include third-party license notices under `third_party_licenses/`.
 
 ## License
 

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -71,8 +71,8 @@ Das Produktions-Build befindet sich in `src-tauri/target/release/bundle/`.
 
 Diese App bündelt oder lädt die folgenden Open-Source-Binärdateien herunter:
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg ist unter der GNU General Public License v3 lizenziert. Der genaue GPL-Build, der mit jedem Release ausgeliefert wird, ist oben verlinkt; der zugehörige Quellcode ist beim FFmpeg-Projekt und den Build-Anbietern verfügbar.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -71,8 +71,8 @@ La compilación de producción se genera en `src-tauri/target/release/bundle/`.
 
 Esta aplicación incluye o descarga los siguientes binarios de código abierto:
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg está licenciado bajo la GNU General Public License v3. La versión GPL exacta incluida en cada lanzamiento se enlaza arriba, con el código fuente correspondiente disponible en el proyecto FFmpeg y los proveedores de compilación.

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -71,8 +71,8 @@ Le résultat de la compilation se trouve dans `src-tauri/target/release/bundle/`
 
 Cette application intègre ou télécharge les binaires open source suivants :
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg est distribué sous GNU General Public License v3. La version GPL exacte fournie avec chaque version est liée ci-dessus, avec le code source correspondant disponible auprès du projet FFmpeg et des fournisseurs de compilation.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -71,8 +71,8 @@ bun run tauri build
 
 このアプリは以下のオープンソースバイナリをバンドルまたはダウンロードします：
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg は GNU General Public License v3 のもとでライセンスされています。各リリースに同梱される GPL ビルドは上記リンクから確認でき、ソースコードは FFmpeg プロジェクトおよびビルド提供者から入手できます。

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -71,8 +71,8 @@ bun run tauri build
 
 이 앱은 다음 오픈소스 바이너리를 번들 또는 다운로드합니다:
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg는 GNU General Public License v3에 따라 라이선스됩니다. 각 릴리스에 포함된 GPL 빌드는 위 링크에서 확인할 수 있으며, 소스 코드는 FFmpeg 프로젝트 및 빌드 제공자로부터 확인할 수 있습니다.

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -71,8 +71,8 @@ A saída da compilação de produção estará em `src-tauri/target/release/bund
 
 Este aplicativo inclui ou baixa os seguintes binários de código aberto:
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg está licenciado sob a GNU General Public License v3. A versão GPL exata incluída em cada lançamento está vinculada acima, com o código-fonte correspondente disponível no projeto FFmpeg e nos provedores de compilação.

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -71,8 +71,8 @@ bun run tauri build
 
 Это приложение поставляется в комплекте или загружает следующие бинарные файлы с открытым исходным кодом:
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg распространяется под лицензией GNU General Public License v3. Точная GPL-сборка, поставляемая с каждым выпуском, указана по ссылкам выше; соответствующий исходный код доступен на сайте проекта FFmpeg и у поставщиков сборок.

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -71,8 +71,8 @@ Kết quả biên dịch sản xuất nằm trong `src-tauri/target/release/bund
 
 Ứng dụng này đóng gói hoặc tải xuống các tệp nhị phân mã nguồn mở sau:
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg được cấp phép theo GNU General Public License v3. Bản build GPL chính xác đi kèm với mỗi phiên bản được liên kết ở trên, mã nguồn tương ứng có thể tìm thấy tại dự án FFmpeg và các nhà cung cấp bản build.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -71,8 +71,8 @@ bun run tauri build
 
 本应用捆绑或下载以下开源二进制文件：
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg 依据 GNU General Public License v3 授权。每个发行版所附带的 GPL 构建版本可通过上方链接查看，相应源代码可从 FFmpeg 项目及构建提供方获取。

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -71,8 +71,8 @@ bun run tauri build
 
 本應用程式捆綁或下載以下開源二進位檔：
 
-- **yt-dlp** — The Unlicense — https://github.com/yt-dlp/yt-dlp
-- **FFmpeg** — GPLv3 — bundled GPL builds: https://github.com/BtbN/FFmpeg-Builds (Windows/Linux), https://github.com/vanloctech/ffmpeg-macos (macOS); source: https://ffmpeg.org
+- **yt-dlp** — Source: The Unlicense; standalone release binaries: GPLv3+ — https://github.com/yt-dlp/yt-dlp
+- **FFmpeg** — GPLv3 — app-managed Windows/Linux builds: https://github.com/BtbN/FFmpeg-Builds; macOS: system FFmpeg or compliant bundled sidecar only; source: https://ffmpeg.org
 - **Deno** — MIT — https://github.com/denoland/deno
 
 FFmpeg 依據 GNU General Public License v3 授權。每個發行版所附帶的 GPL 建置版本可透過上方連結查看，相應原始碼可從 FFmpeg 專案及建置提供方取得。

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "node --test tests/*.test.mjs && node scripts/check-auto-loading-indicator.mjs && node scripts/check-license-compliance.mjs",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "tauri": "tauri",

--- a/scripts/check-license-compliance.mjs
+++ b/scripts/check-license-compliance.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict"
+import { existsSync, readFileSync } from "node:fs"
+
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8")
+
+const readmes = [
+  "README.md",
+  "docs/README.ko.md",
+  "docs/README.ja.md",
+  "docs/README.zh-CN.md",
+  "docs/README.zh-TW.md",
+  "docs/README.fr.md",
+  "docs/README.de.md",
+  "docs/README.es.md",
+  "docs/README.pt-BR.md",
+  "docs/README.ru.md",
+  "docs/README.vi.md",
+]
+
+for (const path of readmes) {
+  const content = read(path)
+  assert.ok(
+    !content.includes("vanloctech/ffmpeg-macos"),
+    `${path} should not reference the nonfree macOS FFmpeg build`,
+  )
+}
+
+const tauriConfig = JSON.parse(read("src-tauri/tauri.conf.json"))
+assert.equal(
+  tauriConfig.bundle.resources["third_party_licenses/*"],
+  "third_party_licenses/",
+  "Tauri bundle should include third-party license resources",
+)
+
+for (const path of [
+  "src-tauri/third_party_licenses/THIRD_PARTY_NOTICES.md",
+  "src-tauri/third_party_licenses/GPL-3.0.txt",
+  "src-tauri/third_party_licenses/DENO-LICENSE.txt",
+]) {
+  assert.ok(existsSync(new URL(`../${path}`, import.meta.url)), `${path} should exist`)
+}
+
+const mainReadme = read("README.md")
+assert.match(
+  mainReadme,
+  /yt-dlp[\s\S]*standalone release binaries[\s\S]*GPLv3\+/i,
+  "README should distinguish yt-dlp source license from standalone binary license",
+)
+assert.match(
+  mainReadme,
+  /macOS[\s\S]*FFmpeg[\s\S]*auto-download[\s\S]*disabled/i,
+  "README should explain the macOS FFmpeg auto-download compliance change",
+)
+
+const settingsPage = read("src/routes/tools/ytdlp/settings/+page.svelte")
+assert.ok(
+  settingsPage.includes("standalone binaries: GPLv3+"),
+  "About screen should disclose yt-dlp standalone binary licensing",
+)
+assert.ok(
+  !settingsPage.includes("vanloctech/ffmpeg-macos"),
+  "About screen should not point users to the nonfree macOS FFmpeg build",
+)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2285,7 +2285,6 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
- "flate2",
  "futures-util",
  "hex",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,7 +51,6 @@ log = "0.4"
 # Dependency auto-download
 reqwest = { version = "0.12", features = ["stream", "json"] }
 zip = "2.1"
-flate2 = "1.0"
 tar = "0.4"
 xz2 = "0.1"
 sha2 = "0.10"
@@ -70,4 +69,3 @@ strip = true      # strip symbols — Tauri's recommended bundle-size win
 # NOTE: deliberately NOT setting panic = "abort". The app relies on unwinding
 # for Mutex-poisoning recovery (db/mod.rs, download/manager.rs) and to isolate
 # per-task panics so one failed download/metadata fetch cannot crash the GUI.
-

--- a/src-tauri/src/ytdlp/dep_download.rs
+++ b/src-tauri/src/ytdlp/dep_download.rs
@@ -234,63 +234,6 @@ pub async fn extract_zip(
     .map_err(|e| AppError::DependencyInstallError(format!("Extract task failed: {}", e)))?
 }
 
-/// Extract a tar.gz archive, finding the specified binaries inside.
-pub async fn extract_tar_gz(
-    archive_path: &Path,
-    dest_dir: &Path,
-    binary_names: &[&str],
-) -> Result<Vec<PathBuf>, AppError> {
-    let archive = archive_path.to_path_buf();
-    let dest = dest_dir.to_path_buf();
-    let names: Vec<String> = binary_names.iter().map(|s| s.to_string()).collect();
-
-    tokio::task::spawn_blocking(move || -> Result<Vec<PathBuf>, AppError> {
-        let file = std::fs::File::open(&archive).map_err(|e| {
-            AppError::DependencyInstallError(format!("Failed to open tar.gz: {}", e))
-        })?;
-        let decoder = flate2::read::GzDecoder::new(file);
-        let mut tar = tar::Archive::new(decoder);
-
-        let mut extracted = Vec::new();
-
-        for entry_result in tar
-            .entries()
-            .map_err(|e| AppError::DependencyInstallError(format!("Tar entries error: {}", e)))?
-        {
-            let mut entry = entry_result
-                .map_err(|e| AppError::DependencyInstallError(format!("Tar entry error: {}", e)))?;
-
-            let path = entry
-                .path()
-                .map_err(|e| AppError::DependencyInstallError(format!("Tar path error: {}", e)))?
-                .to_path_buf();
-
-            let file_name = path
-                .file_name()
-                .map(|f| f.to_string_lossy().to_string())
-                .unwrap_or_default();
-
-            if names.contains(&file_name) {
-                let out_path = dest.join(&file_name);
-                let mut out_file = std::fs::File::create(&out_path).map_err(|e| {
-                    AppError::DependencyInstallError(format!(
-                        "Failed to create extracted file: {}",
-                        e
-                    ))
-                })?;
-                std::io::copy(&mut entry, &mut out_file).map_err(|e| {
-                    AppError::DependencyInstallError(format!("Failed to extract file: {}", e))
-                })?;
-                extracted.push(out_path);
-            }
-        }
-
-        Ok(extracted)
-    })
-    .await
-    .map_err(|e| AppError::DependencyInstallError(format!("Extract task failed: {}", e)))?
-}
-
 /// Extract a tar.xz archive, finding the specified binaries inside.
 pub async fn extract_tar_xz(
     archive_path: &Path,

--- a/src-tauri/src/ytdlp/dep_ffmpeg.rs
+++ b/src-tauri/src/ytdlp/dep_ffmpeg.rs
@@ -6,17 +6,9 @@ use tauri::AppHandle;
 /// Get ffmpeg download URL and archive format for the current platform.
 fn get_download_info() -> Result<(&'static str, ArchiveFormat), AppError> {
     if cfg!(target_os = "macos") {
-        if cfg!(target_arch = "aarch64") {
-            Ok((
-                "https://github.com/vanloctech/ffmpeg-macos/releases/latest/download/ffmpeg-macos-arm64.tar.gz",
-                ArchiveFormat::TarGz,
-            ))
-        } else {
-            Ok((
-                "https://github.com/vanloctech/ffmpeg-macos/releases/latest/download/ffmpeg-macos-x64.tar.gz",
-                ArchiveFormat::TarGz,
-            ))
-        }
+        Err(AppError::DependencyInstallError(
+            "macOS FFmpeg auto-download is disabled until a redistributable GPL/LGPL build is configured. Install FFmpeg with Homebrew or ship a compliant bundled ffmpeg/ffprobe sidecar.".to_string(),
+        ))
     } else if cfg!(target_os = "windows") {
         Ok((
             "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip",
@@ -40,7 +32,6 @@ fn get_download_info() -> Result<(&'static str, ArchiveFormat), AppError> {
 
 enum ArchiveFormat {
     Zip,
-    TarGz,
     TarXz,
 }
 
@@ -66,7 +57,6 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<String, AppError> {
         "ffmpeg_archive.{}",
         match format {
             ArchiveFormat::Zip => "zip",
-            ArchiveFormat::TarGz => "tar.gz",
             ArchiveFormat::TarXz => "tar.xz",
         }
     );
@@ -84,7 +74,6 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<String, AppError> {
 
     let extracted = match format {
         ArchiveFormat::Zip => extract_zip(&archive_path, &bin_dir, binary_names).await?,
-        ArchiveFormat::TarGz => extract_tar_gz(&archive_path, &bin_dir, binary_names).await?,
         ArchiveFormat::TarXz => extract_tar_xz(&archive_path, &bin_dir, binary_names).await?,
     };
 
@@ -118,7 +107,7 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<String, AppError> {
         "ffmpeg"
     };
     let ffmpeg_path = bin_dir.join(ffmpeg_bin);
-    // BtbN/vanloctech "latest" builds publish no stable per-release checksum, so a
+    // Third-party "latest" FFmpeg builds publish no stable per-release checksum, so a
     // successful `ffmpeg -version` is our integrity/sanity gate instead. If the
     // extracted binary does not run, treat the install as failed and remove the
     // broken binaries so a later dependency check does not report them as installed.
@@ -148,29 +137,30 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<String, AppError> {
 /// Get the latest ffmpeg version info.
 pub async fn get_latest_version() -> Result<String, AppError> {
     // BtbN builds use rolling "latest" tag, so we just return a placeholder.
-    // For vanloctech/ffmpeg-macos, check the latest release.
     if cfg!(target_os = "macos") {
-        let client = reqwest::Client::new();
-        let resp = client
-            .get("https://api.github.com/repos/vanloctech/ffmpeg-macos/releases/latest")
-            .header("User-Agent", "modern-ytdlp-gui")
-            .send()
-            .await
-            .map_err(|e| {
-                AppError::NetworkError(format!("Failed to check ffmpeg version: {}", e))
-            })?;
-
-        let json = resp
-            .json::<serde_json::Value>()
-            .await
-            .map_err(|e| AppError::NetworkError(format!("Failed to parse response: {}", e)))?;
-
-        json["tag_name"]
-            .as_str()
-            .map(|s: &str| s.to_string())
-            .ok_or_else(|| AppError::NetworkError("No tag_name in response".to_string()))
+        Ok("system-or-bundled".to_string())
     } else {
         // BtbN uses "latest" rolling release
         Ok("latest".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_ffmpeg_download_does_not_use_nonredistributable_builds() {
+        let err = match get_download_info() {
+            Ok((_url, _format)) => panic!(
+                "macOS FFmpeg auto-download should be disabled until a redistributable build is configured"
+            ),
+            Err(err) => err,
+        };
+
+        let message = err.to_string();
+        assert!(message.contains("macOS"), "{message}");
+        assert!(message.contains("FFmpeg"), "{message}");
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,8 @@
     "createUpdaterArtifacts": true,
     "targets": "all",
     "resources": {
-      "binaries/*": "binaries/"
+      "binaries/*": "binaries/",
+      "third_party_licenses/*": "third_party_licenses/"
     },
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/third_party_licenses/DENO-LICENSE.txt
+++ b/src-tauri/third_party_licenses/DENO-LICENSE.txt
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright 2018-2026 the Deno authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src-tauri/third_party_licenses/GPL-3.0.txt
+++ b/src-tauri/third_party_licenses/GPL-3.0.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/src-tauri/third_party_licenses/THIRD_PARTY_NOTICES.md
+++ b/src-tauri/third_party_licenses/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,40 @@
+# Third-Party Notices
+
+This app uses sidecar command-line tools as separate programs. The app invokes
+them through process execution and keeps user-selectable dependency paths in
+Settings so users can replace app-managed copies with compatible system copies.
+
+## yt-dlp
+
+- Project: https://github.com/yt-dlp/yt-dlp
+- Source license: The Unlicense
+- Standalone release binaries downloaded by this app: GPLv3+
+- Corresponding source: https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.tar.gz
+- Third-party license details: https://github.com/yt-dlp/yt-dlp/blob/master/THIRD_PARTY_LICENSES.txt
+
+The yt-dlp project documents that its source tarball and PyPI distributions
+contain Unlicense code, while PyInstaller-bundled standalone executables include
+GPLv3+ licensed code and are distributed as GPLv3+ combined works.
+
+## FFmpeg
+
+- Project source: https://ffmpeg.org
+- Windows/Linux app-managed builds: https://github.com/BtbN/FFmpeg-Builds
+- Windows/Linux build variant: `gpl`, licensed as GPLv3
+- BtbN build scripts: https://github.com/BtbN/FFmpeg-Builds
+
+The app no longer downloads the previous macOS FFmpeg build because its build
+configuration enabled nonfree components. On macOS, users should use a system
+FFmpeg installation, or app releases must ship a separately built redistributable
+GPL/LGPL FFmpeg sidecar with matching source and build instructions.
+
+## Deno
+
+- Project: https://github.com/denoland/deno
+- License: MIT
+- Third-party license details: https://license.deno.dev/
+
+## License Files
+
+- GPLv3 text: `GPL-3.0.txt`
+- Deno MIT license: `DENO-LICENSE.txt`

--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -256,7 +256,7 @@ const de: Record<string, string> = {
   // About / licenses
   "settings.about": "Über",
   "settings.licensesDesc": "Diese App bündelt oder lädt folgende Open-Source-Tools herunter:",
-  "settings.ffmpegGplNotice": "FFmpeg wird unter der GPLv3 vertrieben; der mitgelieferte GPL-Build und sein Quellcode sind über die obigen Projektlinks verfügbar.",
+  "settings.ffmpegGplNotice": "Unter Windows/Linux nutzt die App verwaltete, weiterverteilbare GPLv3-FFmpeg-Builds. Unter macOS wird System-FFmpeg oder ein konformer gebündelter Sidecar genutzt; Lizenzdateien liegen in third_party_licenses.",
   "settings.openLocation": "Dateispeicherort öffnen",
 
   // Errors (backend i18n keys)

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -266,7 +266,7 @@ const en: Record<string, string> = {
   // About / licenses
   "settings.about": "About",
   "settings.licensesDesc": "This app bundles or downloads these open-source tools:",
-  "settings.ffmpegGplNotice": "FFmpeg is distributed under the GPLv3; the bundled GPL build and its source are available from the project links above.",
+  "settings.ffmpegGplNotice": "Windows/Linux app-managed FFmpeg uses redistributable GPLv3 builds. macOS uses system FFmpeg or a compliant bundled sidecar; license files are included in third_party_licenses.",
   "settings.openLocation": "Open file location",
 
   // Errors (backend i18n keys; see src-tauri metadata/mod.rs, download/executor.rs)

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -260,7 +260,7 @@ const fr: Record<string, string> = {
   // About / licenses
   "settings.about": "À propos",
   "settings.licensesDesc": "Cette application intègre ou télécharge les outils open source suivants :",
-  "settings.ffmpegGplNotice": "FFmpeg est distribué sous licence GPLv3 ; la version GPL fournie et son code source sont disponibles via les liens de projet ci-dessus.",
+  "settings.ffmpegGplNotice": "Sur Windows/Linux, FFmpeg géré par l'application utilise des versions GPLv3 redistribuables. Sur macOS, l'application utilise FFmpeg système ou un sidecar conforme ; les licences sont dans third_party_licenses.",
   "settings.openLocation": "Ouvrir l'emplacement du fichier",
 
   // Errors (backend i18n keys)

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -256,7 +256,7 @@ const ja: Record<string, string> = {
   // About / licenses
   "settings.about": "このアプリについて",
   "settings.licensesDesc": "このアプリは以下のオープンソースツールを同梱またはダウンロードします：",
-  "settings.ffmpegGplNotice": "FFmpeg は GPLv3 ライセンスで配布されています。同梱の GPL ビルドとそのソースコードは上記プロジェクトリンクから入手できます。",
+  "settings.ffmpegGplNotice": "Windows/Linux のアプリ管理 FFmpeg は再配布可能な GPLv3 ビルドを使用します。macOS はシステム FFmpeg または準拠した同梱サイドカーを使用し、ライセンスファイルは third_party_licenses に含まれます。",
   "settings.openLocation": "ファイルの場所を開く",
 
   // Errors (backend i18n keys)

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -258,7 +258,7 @@ const ko: Record<string, string> = {
   // About / licenses
   "settings.about": "정보",
   "settings.licensesDesc": "이 앱은 다음 오픈소스 도구를 포함하거나 다운로드합니다:",
-  "settings.ffmpegGplNotice": "FFmpeg는 GPLv3 라이선스로 배포됩니다. 번들된 GPL 빌드와 소스 코드는 위 프로젝트 링크에서 확인할 수 있습니다.",
+  "settings.ffmpegGplNotice": "Windows/Linux 앱 관리 FFmpeg는 재배포 가능한 GPLv3 빌드를 사용합니다. macOS는 시스템 FFmpeg 또는 준수 번들 사이드카를 사용하며, 라이선스 파일은 third_party_licenses에 포함됩니다.",
   "settings.openLocation": "파일 위치 열기",
 
   // Errors (백엔드 i18n 키; src-tauri metadata/mod.rs, download/executor.rs 참고)

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -260,7 +260,7 @@ const zhCN: Record<string, string> = {
   // About / licenses
   "settings.about": "关于",
   "settings.licensesDesc": "本应用内置或下载了以下开源工具：",
-  "settings.ffmpegGplNotice": "FFmpeg 遵循 GPLv3 协议发布，内置的 GPL 构建版本及其源代码可通过上方项目链接获取。",
+  "settings.ffmpegGplNotice": "Windows/Linux 的应用托管 FFmpeg 使用可再分发的 GPLv3 构建。macOS 使用系统 FFmpeg 或合规的内置 sidecar；许可文件包含在 third_party_licenses 中。",
   "settings.openLocation": "打开文件位置",
 
   // Errors (backend i18n keys)

--- a/src/lib/i18n/locales/zh-TW.ts
+++ b/src/lib/i18n/locales/zh-TW.ts
@@ -260,7 +260,7 @@ const zhTW: Record<string, string> = {
   // About / licenses
   "settings.about": "關於",
   "settings.licensesDesc": "本應用程式內建或下載了以下開源工具：",
-  "settings.ffmpegGplNotice": "FFmpeg 依 GPLv3 授權發布，內建的 GPL 建置版本及其原始碼可透過上方專案連結取得。",
+  "settings.ffmpegGplNotice": "Windows/Linux 的應用程式管理 FFmpeg 使用可再散布的 GPLv3 建置。macOS 使用系統 FFmpeg 或合規的內建 sidecar；授權檔案包含在 third_party_licenses 中。",
   "settings.openLocation": "開啟檔案位置",
 
   // Errors (backend i18n keys)

--- a/src/routes/tools/ytdlp/settings/+page.svelte
+++ b/src/routes/tools/ytdlp/settings/+page.svelte
@@ -151,13 +151,13 @@
             <ul class="space-y-2 text-xs">
                <li class="flex flex-wrap items-baseline gap-x-2">
                   <span class="font-medium text-yt-text">yt-dlp</span>
-                  <span class="text-yt-text-secondary">The Unlicense</span>
+                  <span class="text-yt-text-secondary">source: The Unlicense; standalone binaries: GPLv3+</span>
                   <span class="text-yt-text-secondary/70">github.com/yt-dlp/yt-dlp</span>
                </li>
                <li class="flex flex-wrap items-baseline gap-x-2">
                   <span class="font-medium text-yt-text">FFmpeg</span>
                   <span class="text-yt-text-secondary">GPL v3</span>
-                  <span class="text-yt-text-secondary/70">github.com/BtbN/FFmpeg-Builds · github.com/vanloctech/ffmpeg-macos</span>
+                  <span class="text-yt-text-secondary/70">github.com/BtbN/FFmpeg-Builds (Windows/Linux); macOS uses system FFmpeg or a compliant bundled sidecar</span>
                </li>
                <li class="flex flex-wrap items-baseline gap-x-2">
                   <span class="font-medium text-yt-text">Deno</span>


### PR DESCRIPTION
## Summary
- disable macOS FFmpeg auto-download from the previous nonfree build source while keeping Windows/Linux on BtbN GPL builds
- add bundled third-party license notices/resources and update About/README copy for yt-dlp, FFmpeg, and Deno
- add a license compliance check to npm test and remove the now-unused tar.gz/flate2 direct dependency

## Test Plan
- [x] npm test
- [x] npm run check
- [x] npm run build
- [x] cargo test
- [x] git diff --check HEAD~1..HEAD

## Notes
- npm run build still prints existing unused import and Node DEP0205 deprecation warnings, but exits successfully.