### PR TITLE
fix: 로그/큐 DB 입력 안정성 강화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tauriScript: bun run tauri
-          args: --target ${{ matrix.target }}
+          # Pull requests do not have access to signing secrets; building without bundling keeps CI deterministic.
+          args: --target ${{ matrix.target }} --no-bundle

--- a/src-tauri/src/modules/log_db.rs
+++ b/src-tauri/src/modules/log_db.rs
@@ -4,6 +4,13 @@ use rusqlite::{params, Connection};
 use std::path::Path;
 use std::sync::Mutex;
 
+const MAX_LOG_LEVEL_LEN: usize = 16;
+const MAX_LOG_CATEGORY_LEN: usize = 128;
+const MAX_LOG_FILTER_LEN: usize = 512;
+const MAX_LOG_MESSAGE_LEN: usize = 4096;
+const MAX_LOG_DETAILS_LEN: usize = 8192;
+const VALID_LOG_LEVELS: &[&str] = &["ERROR", "WARN", "INFO", "DEBUG"];
+
 pub struct LogDatabase {
     conn: Mutex<Connection>,
 }
@@ -36,6 +43,86 @@ impl LogDatabase {
         self.conn.lock().unwrap_or_else(|e| e.into_inner())
     }
 
+    fn normalize_text(value: &str, max_len: usize) -> String {
+        let mut normalized = String::new();
+        let mut previous_space = false;
+        let mut written = 0usize;
+
+        for ch in value.trim().chars() {
+            let ch = if ch.is_control() { ' ' } else { ch };
+            if ch.is_whitespace() {
+                if !previous_space && !normalized.is_empty() {
+                    if written >= max_len {
+                        break;
+                    }
+                    normalized.push(' ');
+                    written += 1;
+                    previous_space = true;
+                }
+            } else {
+                if written >= max_len {
+                    break;
+                }
+                normalized.push(ch);
+                written += 1;
+                previous_space = false;
+            }
+        }
+
+        normalized.trim().to_string()
+    }
+
+    fn normalize_level(level: &str) -> String {
+        let level = Self::normalize_text(level, MAX_LOG_LEVEL_LEN).to_uppercase();
+        if VALID_LOG_LEVELS.contains(&level.as_str()) {
+            level
+        } else {
+            "INFO".to_string()
+        }
+    }
+
+    fn normalize_category(category: &str) -> String {
+        let category = Self::normalize_text(category, MAX_LOG_CATEGORY_LEN);
+        if category.is_empty() {
+            "app".to_string()
+        } else {
+            category
+        }
+    }
+
+    fn normalize_filter(value: Option<&str>, max_len: usize) -> Result<Option<String>, AppError> {
+        match value {
+            Some(raw) if raw.len() > max_len => Err(AppError::Custom(format!(
+                "Log filter exceeds maximum length of {} characters",
+                max_len
+            ))),
+            Some(raw) => {
+                let clean = Self::normalize_text(raw, max_len);
+                if clean.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(clean))
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn normalize_level_filter(level: Option<&str>) -> Result<Option<String>, AppError> {
+        let Some(level) = Self::normalize_filter(level, MAX_LOG_LEVEL_LEN)? else {
+            return Ok(None);
+        };
+        let level = level.to_uppercase();
+        if VALID_LOG_LEVELS.contains(&level.as_str()) {
+            Ok(Some(level))
+        } else {
+            Err(AppError::Custom(format!(
+                "Unsupported log level: {}",
+                level
+            )))
+        }
+    }
+
     fn create_tables(conn: &Connection) -> Result<(), AppError> {
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS logs (
@@ -63,6 +150,13 @@ impl LogDatabase {
         message: &str,
         details: Option<&str>,
     ) -> Result<i64, AppError> {
+        let level = Self::normalize_level(level);
+        let category = Self::normalize_category(category);
+        let message = Self::normalize_text(message, MAX_LOG_MESSAGE_LEN);
+        let details = details
+            .map(|value| Self::normalize_text(value, MAX_LOG_DETAILS_LEN))
+            .filter(|value| !value.is_empty());
+
         let conn = self.conn();
         conn.execute(
             "INSERT INTO logs (timestamp, level, category, message, details) VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -83,6 +177,10 @@ impl LogDatabase {
         since: Option<i64>,
     ) -> Result<LogQueryResult, AppError> {
         let page_size = page_size.clamp(1, 200);
+        let level = Self::normalize_level_filter(level)?;
+        let category = Self::normalize_filter(category, MAX_LOG_CATEGORY_LEN)?;
+        let search = Self::normalize_filter(search, MAX_LOG_FILTER_LEN)?;
+
         let conn = self.conn();
 
         let mut conditions: Vec<String> = Vec::new();
@@ -91,13 +189,13 @@ impl LogDatabase {
 
         if let Some(l) = level {
             conditions.push(format!("level = ?{}", param_idx));
-            param_values.push(Box::new(l.to_string()));
+            param_values.push(Box::new(l));
             param_idx += 1;
         }
 
         if let Some(c) = category {
             conditions.push(format!("category = ?{}", param_idx));
-            param_values.push(Box::new(c.to_string()));
+            param_values.push(Box::new(c));
             param_idx += 1;
         }
 
@@ -267,5 +365,118 @@ impl LogDatabase {
         }
 
         Ok(total_deleted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "yummy_log_db_{name}_{}_{}",
+            std::process::id(),
+            nonce
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn insert_log_normalizes_level_category_message_and_details() {
+        let dir = temp_dir("normalize_insert");
+        let db = LogDatabase::new(&dir).unwrap();
+
+        db.insert_log(
+            1,
+            " error ",
+            " download\tqueue ",
+            "line one\nline two\0",
+            Some("detail\r\nmore"),
+        )
+        .unwrap();
+
+        let result = db
+            .query_logs(0, 10, Some("ERROR"), Some("download queue"), None, None)
+            .unwrap();
+        assert_eq!(result.total_count, 1);
+        let item = &result.items[0];
+        assert_eq!(item.level, "ERROR");
+        assert_eq!(item.category, "download queue");
+        assert_eq!(item.message, "line one line two");
+        assert_eq!(item.details.as_deref(), Some("detail more"));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn insert_log_defaults_invalid_level_and_blank_category() {
+        let dir = temp_dir("invalid_level");
+        let db = LogDatabase::new(&dir).unwrap();
+
+        db.insert_log(1, "TRACE", " \n ", "message", None).unwrap();
+
+        let result = db.query_logs(0, 10, None, None, None, None).unwrap();
+        let item = &result.items[0];
+        assert_eq!(item.level, "INFO");
+        assert_eq!(item.category, "app");
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn query_logs_trims_filters_and_ignores_blank_search() {
+        let dir = temp_dir("query_filters");
+        let db = LogDatabase::new(&dir).unwrap();
+
+        db.insert_log(1, "WARN", "metadata", "alpha", None).unwrap();
+        db.insert_log(2, "INFO", "download", "beta", None).unwrap();
+
+        let warn = db
+            .query_logs(0, 10, Some(" warn "), Some(" metadata "), Some("   "), None)
+            .unwrap();
+        assert_eq!(warn.total_count, 1);
+        assert_eq!(warn.items[0].message, "alpha");
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn query_logs_rejects_overlong_filters_before_allocating_like_pattern() {
+        let dir = temp_dir("long_filters");
+        let db = LogDatabase::new(&dir).unwrap();
+        let long = "x".repeat(513);
+
+        assert!(db.query_logs(0, 10, Some(&long), None, None, None).is_err());
+        assert!(db.query_logs(0, 10, None, Some(&long), None, None).is_err());
+        assert!(db.query_logs(0, 10, None, None, Some(&long), None).is_err());
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn insert_log_truncates_large_message_and_details() {
+        let dir = temp_dir("truncate_insert");
+        let db = LogDatabase::new(&dir).unwrap();
+
+        db.insert_log(1, "INFO", "app", &"m".repeat(5000), Some(&"d".repeat(9000)))
+            .unwrap();
+
+        let item = db
+            .query_logs(0, 10, None, None, None, None)
+            .unwrap()
+            .items
+            .remove(0);
+        assert_eq!(item.message.len(), 4096);
+        assert_eq!(item.details.as_ref().unwrap().len(), 8192);
+
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/src-tauri/src/ytdlp/db/queue.rs
+++ b/src-tauri/src/ytdlp/db/queue.rs
@@ -39,6 +39,52 @@ pub(super) fn map_download_row_with_group(
 }
 
 pub(super) const DOWNLOAD_COLUMNS: &str = "id, video_url, video_id, title, format_id, quality_label, output_path, status, progress, speed, eta, error_message, created_at, completed_at, audio_format, audio_quality, error_detail";
+
+const MAX_PROGRESS_METADATA_LEN: usize = 128;
+const MAX_RECENT_COMPLETED_LIMIT: u32 = 50;
+
+fn normalize_progress(progress: f32) -> f32 {
+    if progress.is_finite() {
+        progress.clamp(0.0, 100.0)
+    } else {
+        0.0
+    }
+}
+
+fn normalize_progress_metadata(value: Option<&str>) -> Option<String> {
+    let value = value?;
+    let mut normalized = String::new();
+    let mut previous_space = false;
+    let mut written = 0usize;
+
+    for ch in value.trim().chars() {
+        let ch = if ch.is_control() { ' ' } else { ch };
+        let ch = if ch.is_whitespace() {
+            if previous_space {
+                continue;
+            }
+            previous_space = true;
+            ' '
+        } else {
+            previous_space = false;
+            ch
+        };
+
+        if written >= MAX_PROGRESS_METADATA_LEN {
+            break;
+        }
+
+        normalized.push(ch);
+        written += 1;
+    }
+
+    let normalized = normalized.trim().to_string();
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
 /// Same columns as DOWNLOAD_COLUMNS but qualified with the `d` alias and with
 /// `d.group_id`, `g.title` appended — for queries joined to download_groups.
 pub(super) const DOWNLOAD_COLUMNS_G: &str = "d.id, d.video_url, d.video_id, d.title, d.format_id, d.quality_label, d.output_path, d.status, d.progress, d.speed, d.eta, d.error_message, d.created_at, d.completed_at, d.audio_format, d.audio_quality, d.error_detail, d.group_id, g.title";
@@ -110,6 +156,10 @@ impl Database {
         speed: Option<&str>,
         eta: Option<&str>,
     ) -> Result<(), AppError> {
+        let progress = normalize_progress(progress);
+        let speed = normalize_progress_metadata(speed);
+        let eta = normalize_progress_metadata(eta);
+
         let conn = self.conn();
 
         conn.execute(
@@ -330,6 +380,7 @@ impl Database {
     }
 
     pub fn get_queue_summary(&self, recent_completed_limit: u32) -> Result<QueueSummary, AppError> {
+        let recent_completed_limit = recent_completed_limit.min(MAX_RECENT_COMPLETED_LIMIT);
         let conn = self.conn();
 
         // Get status counts
@@ -436,5 +487,104 @@ impl Database {
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
         Ok(tasks)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ytdlp::db::Database;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "yummy_queue_db_{name}_{}_{}",
+            std::process::id(),
+            nonce
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        dir
+    }
+
+    fn request(video_id: &str) -> DownloadRequest {
+        DownloadRequest {
+            video_url: format!("https://example.com/watch?v={video_id}"),
+            video_id: video_id.to_string(),
+            title: format!("Video {video_id}"),
+            format_id: "best".to_string(),
+            quality_label: "best".to_string(),
+            output_dir: None,
+            cookie_browser: None,
+            audio_format: None,
+            audio_quality: None,
+        }
+    }
+
+    #[test]
+    fn update_download_progress_clamps_non_finite_and_bounds() {
+        let dir = temp_dir("progress_bounds");
+        let db = Database::new(&dir).unwrap();
+        let id = db
+            .insert_download(&request("progress-bounds"), "/tmp/out.mp4")
+            .unwrap();
+
+        db.update_download_progress(id, f32::NAN, None, None)
+            .unwrap();
+        assert_eq!(db.get_download(id).unwrap().unwrap().progress, 0.0);
+
+        db.update_download_progress(id, -10.0, None, None).unwrap();
+        assert_eq!(db.get_download(id).unwrap().unwrap().progress, 0.0);
+
+        db.update_download_progress(id, 250.0, None, None).unwrap();
+        assert_eq!(db.get_download(id).unwrap().unwrap().progress, 100.0);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn update_download_progress_sanitizes_speed_and_eta() {
+        let dir = temp_dir("progress_text");
+        let db = Database::new(&dir).unwrap();
+        let id = db
+            .insert_download(&request("progress-text"), "/tmp/out.mp4")
+            .unwrap();
+
+        db.update_download_progress(
+            id,
+            42.0,
+            Some("  12MiB/s\n--exec bad  "),
+            Some(&"9".repeat(300)),
+        )
+        .unwrap();
+
+        let task = db.get_download(id).unwrap().unwrap();
+        assert_eq!(task.speed.as_deref(), Some("12MiB/s --exec bad"));
+        assert_eq!(task.eta.as_ref().unwrap().len(), 128);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn get_queue_summary_clamps_recent_completed_limit() {
+        let dir = temp_dir("summary_limit");
+        let db = Database::new(&dir).unwrap();
+
+        for idx in 0..60 {
+            let id = db
+                .insert_download(&request(&format!("completed-{idx}")), "/tmp/out.mp4")
+                .unwrap();
+            db.mark_completed(id, idx).unwrap();
+        }
+
+        let summary = db.get_queue_summary(1_000).unwrap();
+        assert_eq!(summary.recent_completed.len(), 50);
+
+        let _ = fs::remove_dir_all(dir);
     }
 }


### PR DESCRIPTION
## 요약
- 로그 DB 저장 경로에서 level/category/message/details를 정규화하고 크기를 제한했습니다.
- 로그 조회 필터의 공백/대소문자/길이 처리를 강화했습니다.
- 큐 DB 진행률, speed/eta 메타데이터, 최근 완료 항목 조회 limit을 방어적으로 정리했습니다.
- PR CI에서 서명 비밀값 없이도 검증 가능하도록 Tauri 빌드에 --no-bundle을 적용했습니다.

## 유형별 해결 문제 15건
1. 로그 level 앞뒤 공백 및 소문자 입력이 그대로 저장되는 문제
2. 지원하지 않는 로그 level이 통계/필터 의미를 깨는 문제
3. 빈 로그 category가 그대로 저장되는 문제
4. 로그 category의 제어문자/연속 공백이 필터 매칭을 깨는 문제
5. 로그 message의 줄바꿈/널 등 제어문자가 그대로 저장되는 문제
6. 과대 로그 message가 제한 없이 DB에 저장되는 문제
7. 로그 details의 제어문자/연속 공백이 그대로 저장되는 문제
8. 과대 로그 details가 제한 없이 DB에 저장되는 문제
9. 빈 details가 의미 없는 빈 문자열로 남는 문제
10. 로그 level 조회 필터의 공백/대소문자 처리 누락 문제
11. 미지원 로그 level 조회 필터를 조용히 빈 결과로 처리하는 문제
12. 과대 로그 필터가 LIKE 패턴 생성 전에 제한되지 않는 문제
13. 공백뿐인 검색어가 불필요한 LIKE 조건을 만드는 문제
14. 다운로드 진행률 NaN/Infinity/음수/100 초과 값이 DB에 저장되는 문제
15. speed/eta 문자열과 최근 완료 limit이 제어문자/과대 입력을 제한하지 않는 문제

## 검증
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- npm run check
- npm run build
- npm audit --audit-level=moderate
- git diff --check