### PR TITLE
fix: survive corrupt databases and interrupted migrations, bound queue growth

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,9 +105,14 @@ pub fn run() {
 
             modules::logger::init(app_data_dir.clone());
 
-            // Initialize log database (separate logs.db file)
-            let log_db = modules::log_db::LogDatabase::new(&app_data_dir)
-                .expect("Failed to initialize log database");
+            // Initialize log database (separate logs.db file). A corrupt/unopenable
+            // logs.db must not brick startup: quarantine + retry, then in-memory fallback.
+            let log_db = open_db_resilient(
+                &app_data_dir,
+                "logs.db",
+                || modules::log_db::LogDatabase::new(&app_data_dir),
+                modules::log_db::LogDatabase::new_in_memory,
+            )?;
             let log_db = Arc::new(log_db);
             modules::logger::init_db(Arc::clone(&log_db));
             modules::logger::init_app_handle(app.handle().clone());
@@ -120,8 +125,14 @@ pub fn run() {
 
             modules::logger::info_cat("app", "Application started");
 
-            let db =
-                ytdlp::db::Database::new(&app_data_dir).expect("Failed to initialize database");
+            // A corrupt/unopenable ytdlp.db must not brick startup either: quarantine the
+            // bad file (never delete it) + retry, then in-memory fallback as last resort.
+            let db = open_db_resilient(
+                &app_data_dir,
+                "ytdlp.db",
+                || ytdlp::db::Database::new(&app_data_dir),
+                ytdlp::db::Database::new_in_memory,
+            )?;
             // Reset stale downloads left in 'downloading' state from previous session
             if let Ok(count) = db.reset_stale_downloads() {
                 if count > 0 {
@@ -130,6 +141,24 @@ pub fn run() {
                         &format!("Reset {} stale downloads from previous session", count),
                     );
                 }
+            }
+            // Prune terminal queue rows (completed/failed/cancelled) older than 30 days so
+            // the downloads table — polled in full by the queue page — stays bounded.
+            // Completed items are already mirrored into history, so nothing is lost.
+            match db.prune_old_terminal_downloads(30) {
+                Ok(count) if count > 0 => {
+                    modules::logger::info_cat(
+                        "app",
+                        &format!("Pruned {} finished queue entries older than 30 days", count),
+                    );
+                }
+                Err(e) => {
+                    modules::logger::warn_cat(
+                        "app",
+                        &format!("Failed to prune old queue entries: {}", e),
+                    );
+                }
+                _ => {}
             }
             app.manage(Arc::new(db));
 
@@ -218,4 +247,97 @@ pub fn run() {
                 app_handle.state::<ScanManagerState>().cancel_current();
             }
         });
+}
+
+/// True for SQLite corruption-class open failures (SQLITE_NOTADB / SQLITE_CORRUPT), where
+/// the on-disk file is unusable and quarantining it is the only way forward. Transient
+/// failures (disk full, locked, permissions) must NOT match — the data is intact there.
+fn is_db_corruption_error(message: &str) -> bool {
+    message.contains("file is not a database")
+        || message.contains("database disk image is malformed")
+}
+
+/// Move `file_name` and its `-wal`/`-shm` siblings aside as `*.corrupt-<timestamp>`.
+/// Returns true only if every existing file was moved — a stale -wal left next to a fresh
+/// db file would itself make the retry fail. Never deletes user data.
+fn quarantine_db_files(app_data_dir: &std::path::Path, file_name: &str) -> bool {
+    let ts = chrono::Utc::now().timestamp();
+    let mut all_moved = true;
+    for suffix in ["", "-wal", "-shm"] {
+        let src = app_data_dir.join(format!("{}{}", file_name, suffix));
+        if src.exists() {
+            let dst = app_data_dir.join(format!("{}{}.corrupt-{}", file_name, suffix, ts));
+            if let Err(e) = std::fs::rename(&src, &dst) {
+                eprintln!(
+                    "[Startup] Failed to quarantine {}: {}",
+                    src.to_string_lossy(),
+                    e
+                );
+                all_moved = false;
+            }
+        }
+    }
+    all_moved
+}
+
+/// Open a database with corruption recovery so one bad file can't permanently brick
+/// startup: on a corruption-class error, quarantine the file (plus WAL/SHM siblings) and
+/// retry once; on transient errors or a failed retry, fall back to an in-memory database
+/// for this session. The in-memory fallback is required — lib.rs manages the handles as
+/// Tauri state, and skipping app.manage() would panic every command at invoke time.
+/// Logged via modules::logger: logger::init runs before either DB init, so the ytdlp.db
+/// quarantine reaches logs.db + the live log view, while a logs.db quarantine can only
+/// reach log.txt.
+fn open_db_resilient<T>(
+    app_data_dir: &std::path::Path,
+    file_name: &str,
+    open: impl Fn() -> Result<T, modules::types::AppError>,
+    open_in_memory: impl FnOnce() -> Result<T, modules::types::AppError>,
+) -> Result<T, modules::types::AppError> {
+    let err = match open() {
+        Ok(db) => return Ok(db),
+        Err(e) => e,
+    };
+
+    let msg = err.to_string();
+    if is_db_corruption_error(&msg) {
+        modules::logger::error_cat(
+            "app",
+            &format!(
+                "{} is corrupted ({}); moving it aside and recreating",
+                file_name, msg
+            ),
+        );
+        if quarantine_db_files(app_data_dir, file_name) {
+            match open() {
+                Ok(db) => {
+                    modules::logger::warn_cat(
+                        "app",
+                        &format!(
+                            "{} recreated after corruption; previous data kept as {}.corrupt-*",
+                            file_name, file_name
+                        ),
+                    );
+                    return Ok(db);
+                }
+                Err(e) => {
+                    modules::logger::error_cat(
+                        "app",
+                        &format!("Failed to recreate {} after quarantine: {}", file_name, e),
+                    );
+                }
+            }
+        }
+    } else {
+        modules::logger::error_cat("app", &format!("Failed to open {}: {}", file_name, msg));
+    }
+
+    modules::logger::error_cat(
+        "app",
+        &format!(
+            "Falling back to an in-memory {} for this session; data will not persist",
+            file_name
+        ),
+    );
+    open_in_memory()
 }

--- a/src-tauri/src/modules/log_db.rs
+++ b/src-tauri/src/modules/log_db.rs
@@ -18,12 +18,28 @@ impl LogDatabase {
         let conn =
             Connection::open(&db_path).map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
-        // WAL mode + relaxed sync for write performance
+        // WAL mode + relaxed sync for write performance. busy_timeout avoids dropping
+        // records with an immediate SQLITE_BUSY under cross-process contention (e.g. an
+        // external sqlite3 shell inspecting logs.db per the debugging workflow).
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
-             PRAGMA synchronous=NORMAL;",
+             PRAGMA synchronous=NORMAL;
+             PRAGMA busy_timeout=5000;",
         )
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        Self::create_tables(&conn)?;
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// In-memory fallback used when logs.db cannot be opened or recreated, so the app
+    /// still launches (structured logs simply don't persist for this session).
+    pub fn new_in_memory() -> Result<Self, AppError> {
+        let conn =
+            Connection::open_in_memory().map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
         Self::create_tables(&conn)?;
 

--- a/src-tauri/src/modules/logger.rs
+++ b/src-tauri/src/modules/logger.rs
@@ -2,6 +2,7 @@ use chrono::Local;
 use std::fs::{self, create_dir_all, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, OnceLock};
 
@@ -74,25 +75,40 @@ fn write_record(rec: &LogRecord) {
 
     // 2. DB logging + 3. event emission for live updates
     if let Some(db) = LOG_DB.get() {
-        if let Ok(id) = db.insert_log(
+        let id = match db.insert_log(
             rec.timestamp_millis,
             &rec.level,
             &rec.category,
             &rec.message,
             rec.details.as_deref(),
         ) {
-            if let Some(app) = APP_HANDLE.get() {
-                use tauri::Emitter;
-                let entry = crate::ytdlp::types::LogEntry {
-                    id,
-                    timestamp: rec.timestamp_millis,
-                    level: rec.level.clone(),
-                    category: rec.category.clone(),
-                    message: rec.message.clone(),
-                    details: rec.details.clone(),
-                };
-                let _ = app.emit("new-log-event", crate::ytdlp::types::NewLogEvent { entry });
+            Ok(id) => id,
+            Err(e) => {
+                // Don't lose the record silently: leave a stderr trace including details
+                // (the text log line omits them) and still emit to the live viewer below.
+                // The synthetic id is negative so it can never collide with a real rowid
+                // (>= 1) — the Logs page keys its {#each} on entry.id and Svelte throws
+                // on duplicate keys.
+                eprintln!(
+                    "[Logger] Failed to insert log into logs.db: {} (dropped: [{}] [{}] {} details={:?})",
+                    e, rec.level, rec.category, rec.message, rec.details
+                );
+                static FALLBACK_LOG_ID: AtomicI64 = AtomicI64::new(-1);
+                FALLBACK_LOG_ID.fetch_sub(1, Ordering::Relaxed)
             }
+        };
+
+        if let Some(app) = APP_HANDLE.get() {
+            use tauri::Emitter;
+            let entry = crate::ytdlp::types::LogEntry {
+                id,
+                timestamp: rec.timestamp_millis,
+                level: rec.level.clone(),
+                category: rec.category.clone(),
+                message: rec.message.clone(),
+                details: rec.details.clone(),
+            };
+            let _ = app.emit("new-log-event", crate::ytdlp::types::NewLogEvent { entry });
         }
     }
 }

--- a/src-tauri/src/ytdlp/db/mod.rs
+++ b/src-tauri/src/ytdlp/db/mod.rs
@@ -42,6 +42,20 @@ impl Database {
         })
     }
 
+    /// In-memory fallback used when ytdlp.db cannot be opened or recreated, so the app
+    /// still launches (queue/history simply don't persist for this session).
+    pub fn new_in_memory() -> Result<Self, AppError> {
+        let conn =
+            Connection::open_in_memory().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        Self::create_tables(&conn)?;
+        Self::run_migrations(&conn)?;
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
     fn get_schema_version(conn: &Connection) -> Result<u32, AppError> {
         conn.execute(
             "CREATE TABLE IF NOT EXISTS _schema_version (version INTEGER NOT NULL)",
@@ -82,9 +96,16 @@ impl Database {
     fn run_migrations(conn: &Connection) -> Result<(), AppError> {
         let current = Self::get_schema_version(conn)?;
 
+        // Every step is idempotent (ensure_column / IF NOT EXISTS) and persists its version
+        // immediately after it succeeds, so an upgrade interrupted mid-way (crash, power loss,
+        // disk full) resumes from the last completed step on the next launch instead of
+        // re-running a bare ALTER, hitting "duplicate column name" and bricking startup.
+        // set_schema_version issues its own BEGIN IMMEDIATE, so steps cannot be wrapped in an
+        // outer transaction — idempotency is what makes the per-step commits safe.
         if current < 1 {
             // v1: Initial schema (tables already created by create_tables)
             // No additional migration needed for fresh installs
+            Self::set_schema_version(conn, 1)?;
         }
 
         if current < 2 {
@@ -96,6 +117,7 @@ impl Database {
                  CREATE INDEX IF NOT EXISTS idx_history_downloaded_at ON history(downloaded_at);",
             )
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            Self::set_schema_version(conn, 2)?;
         }
 
         if current < 3 {
@@ -105,25 +127,26 @@ impl Database {
                  CREATE INDEX IF NOT EXISTS idx_downloads_created_at ON downloads(created_at);",
             )
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            Self::set_schema_version(conn, 3)?;
         }
 
         if current < 4 {
             // v4: Add audio_format column for audio extraction (e.g. mp3)
-            conn.execute_batch("ALTER TABLE downloads ADD COLUMN audio_format TEXT;")
-                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            Self::ensure_column(conn, "downloads", "audio_format", "TEXT")?;
+            Self::set_schema_version(conn, 4)?;
         }
 
         if current < 5 {
             // v5: Add audio_quality column for audio bitrate/quality selection
-            conn.execute_batch("ALTER TABLE downloads ADD COLUMN audio_quality TEXT;")
-                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            Self::ensure_column(conn, "downloads", "audio_quality", "TEXT")?;
+            Self::set_schema_version(conn, 5)?;
         }
 
         if current < 6 {
             // v6: Store the raw yt-dlp error line for failed downloads so the UI can show
             // the real cause instead of only the generic classified message.
-            conn.execute_batch("ALTER TABLE downloads ADD COLUMN error_detail TEXT;")
-                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            Self::ensure_column(conn, "downloads", "error_detail", "TEXT")?;
+            Self::set_schema_version(conn, 6)?;
         }
 
         if current < 7 {
@@ -137,21 +160,9 @@ impl Database {
                     kind TEXT NOT NULL DEFAULT 'playlist',
                     total_count INTEGER NOT NULL DEFAULT 0,
                     created_at INTEGER NOT NULL
-                );
-                ALTER TABLE downloads ADD COLUMN group_id INTEGER;
-                ALTER TABLE history ADD COLUMN group_id INTEGER;
-                CREATE INDEX IF NOT EXISTS idx_downloads_group_id ON downloads(group_id);
-                CREATE INDEX IF NOT EXISTS idx_history_group_id ON history(group_id);",
+                );",
             )
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-        }
-
-        if current < 8 {
-            // v8: Repair installs stuck on v7. v7 bundled `ALTER TABLE history ADD COLUMN group_id`
-            // into one execute_batch; where `downloads.group_id` already existed that batch aborted
-            // early and left `history.group_id` missing, so every completed download failed to
-            // record into history and duplicate detection never recognized anything. ensure_column
-            // re-adds whatever is absent, idempotently.
             Self::ensure_column(conn, "downloads", "group_id", "INTEGER")?;
             Self::ensure_column(conn, "history", "group_id", "INTEGER")?;
             conn.execute_batch(
@@ -159,9 +170,29 @@ impl Database {
                  CREATE INDEX IF NOT EXISTS idx_history_group_id ON history(group_id);",
             )
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            Self::set_schema_version(conn, 7)?;
         }
 
-        if current < SCHEMA_VERSION {
+        if current < 8 {
+            // v8: Repair installs stuck on v7. v7 bundled `ALTER TABLE history ADD COLUMN group_id`
+            // into one execute_batch; where `downloads.group_id` already existed that batch aborted
+            // early and left `history.group_id` missing, so every completed download failed to
+            // record into history and duplicate detection never recognized anything. ensure_column
+            // re-adds whatever is absent, idempotently. (v7 above now uses ensure_column itself,
+            // making this redundant for new upgrades but still required for old broken installs.)
+            Self::ensure_column(conn, "downloads", "group_id", "INTEGER")?;
+            Self::ensure_column(conn, "history", "group_id", "INTEGER")?;
+            conn.execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_downloads_group_id ON downloads(group_id);
+                 CREATE INDEX IF NOT EXISTS idx_history_group_id ON history(group_id);",
+            )
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            Self::set_schema_version(conn, 8)?;
+        }
+
+        // Safety net: keep the recorded version current even if a future step forgets its
+        // per-step write (re-read because the steps above advance the stored version).
+        if Self::get_schema_version(conn)? < SCHEMA_VERSION {
             Self::set_schema_version(conn, SCHEMA_VERSION)?;
         }
 
@@ -298,6 +329,31 @@ mod tests {
             [],
         )
         .unwrap();
+    }
+
+    #[test]
+    fn migration_resumes_after_interrupted_step_without_duplicate_column_error() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Reproduce an upgrade killed after the v4 ALTER succeeded but before the version
+        // was persisted: audio_format already exists while the recorded version is still 3.
+        // Re-running migrations must not fail with "duplicate column name".
+        conn.execute_batch(
+            "CREATE TABLE downloads (id INTEGER PRIMARY KEY, video_id TEXT NOT NULL, status TEXT, created_at INTEGER, completed_at INTEGER, audio_format TEXT);
+             CREATE TABLE history (id INTEGER PRIMARY KEY, video_id TEXT NOT NULL, downloaded_at INTEGER);
+             CREATE TABLE _schema_version (version INTEGER NOT NULL);
+             INSERT INTO _schema_version (version) VALUES (3);",
+        )
+        .unwrap();
+
+        Database::run_migrations(&conn).unwrap();
+
+        for column in ["audio_format", "audio_quality", "error_detail", "group_id"] {
+            assert!(column_names(&conn, "downloads").iter().any(|c| c == column));
+        }
+        assert!(column_names(&conn, "history")
+            .iter()
+            .any(|c| c == "group_id"));
+        assert_eq!(Database::get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
     }
 
     #[test]

--- a/src-tauri/src/ytdlp/db/queue.rs
+++ b/src-tauri/src/ytdlp/db/queue.rs
@@ -329,6 +329,22 @@ impl Database {
         Ok(rows as u32)
     }
 
+    /// Delete terminal queue rows older than `max_age_days` so the downloads table stays
+    /// bounded; nothing else ever removes failed/cancelled rows. Completed rows are mirrored
+    /// into history at completion time (complete_and_record), so pruning them loses nothing.
+    /// download_groups rows are intentionally left alone — the history view JOINs them.
+    pub fn prune_old_terminal_downloads(&self, max_age_days: u32) -> Result<u32, AppError> {
+        let conn = self.conn();
+        let cutoff = chrono::Utc::now().timestamp() - (max_age_days as i64 * 24 * 60 * 60);
+        let rows = conn
+            .execute(
+                "DELETE FROM downloads WHERE status IN ('completed', 'failed', 'cancelled') AND created_at < ?1",
+                params![cutoff],
+            )
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        Ok(rows as u32)
+    }
+
     pub fn get_queue_summary(&self, recent_completed_limit: u32) -> Result<QueueSummary, AppError> {
         let conn = self.conn();
 
@@ -420,12 +436,31 @@ impl Database {
     /// history table and are shown in the records section instead.
     /// Rows backing the queue page's status filters. Includes `completed` so the "Completed"
     /// filter tab can list finished downloads; the page keeps them out of the default view.
+    ///
+    /// All 'downloading'/'pending' rows are always returned unbounded (a global LIMIT could
+    /// hide genuinely active items behind newer terminal rows); only terminal rows are capped
+    /// at the newest ACTIVE_QUEUE_TERMINAL_LIMIT, since this query is polled every 5s and
+    /// re-serialized over IPC in full. Note: the queue page's filter-tab counts are derived
+    /// from this array, so terminal counts undercount once the cap is exceeded — acceptable
+    /// because the startup prune (prune_old_terminal_downloads) keeps the table bounded.
     pub fn get_active_queue(&self) -> Result<Vec<DownloadTaskInfo>, AppError> {
+        const ACTIVE_QUEUE_TERMINAL_LIMIT: u32 = 1000;
+
         let conn = self.conn();
         let mut stmt = conn
             .prepare(&format!(
-                "SELECT {} FROM downloads d LEFT JOIN download_groups g ON g.id = d.group_id WHERE d.status IN ('downloading', 'pending', 'failed', 'cancelled', 'completed') ORDER BY d.created_at DESC",
-                DOWNLOAD_COLUMNS_G
+                "SELECT {} FROM downloads d LEFT JOIN download_groups g ON g.id = d.group_id
+                 WHERE d.id IN (
+                     SELECT id FROM downloads WHERE status IN ('downloading', 'pending')
+                     UNION ALL
+                     SELECT id FROM (
+                         SELECT id FROM downloads
+                         WHERE status IN ('failed', 'cancelled', 'completed')
+                         ORDER BY created_at DESC LIMIT {}
+                     )
+                 )
+                 ORDER BY d.created_at DESC",
+                DOWNLOAD_COLUMNS_G, ACTIVE_QUEUE_TERMINAL_LIMIT
             ))
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
@@ -436,5 +471,73 @@ impl Database {
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
         Ok(tasks)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn insert_row(db: &Database, status: &str, created_at: i64) -> i64 {
+        let conn = db.conn();
+        conn.execute(
+            "INSERT INTO downloads (video_url, video_id, title, format_id, quality_label, output_path, status, created_at)
+             VALUES ('https://example.com/v', 'vid', 'title', 'fmt', '1080p', '/tmp', ?1, ?2)",
+            params![status, created_at],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    #[test]
+    fn prune_removes_only_old_terminal_rows() {
+        let db = Database::new_in_memory().unwrap();
+        let now = chrono::Utc::now().timestamp();
+        let old = now - 40 * 24 * 60 * 60;
+
+        let old_completed = insert_row(&db, "completed", old);
+        let old_failed = insert_row(&db, "failed", old);
+        let old_pending = insert_row(&db, "pending", old);
+        let recent_failed = insert_row(&db, "failed", now);
+
+        let pruned = db.prune_old_terminal_downloads(30).unwrap();
+        assert_eq!(pruned, 2);
+
+        let remaining: Vec<i64> = {
+            let conn = db.conn();
+            let mut stmt = conn.prepare("SELECT id FROM downloads").unwrap();
+            stmt.query_map([], |row| row.get(0))
+                .unwrap()
+                .collect::<rusqlite::Result<Vec<i64>>>()
+                .unwrap()
+        };
+        assert!(remaining.contains(&old_pending));
+        assert!(remaining.contains(&recent_failed));
+        assert!(!remaining.contains(&old_completed));
+        assert!(!remaining.contains(&old_failed));
+    }
+
+    #[test]
+    fn get_active_queue_never_drops_active_rows_beyond_terminal_cap() {
+        let db = Database::new_in_memory().unwrap();
+        let base = chrono::Utc::now().timestamp();
+
+        // One old pending row buried under far more than the terminal cap of newer rows.
+        let pending_id = insert_row(&db, "pending", base - 10_000);
+        for i in 0..1100i64 {
+            insert_row(&db, "failed", base + i);
+        }
+
+        let tasks = db.get_active_queue().unwrap();
+
+        assert!(
+            tasks.iter().any(|t| t.id as i64 == pending_id),
+            "active row must never be hidden by the terminal cap"
+        );
+        let terminal_count = tasks
+            .iter()
+            .filter(|t| matches!(t.status, DownloadStatus::Failed))
+            .count();
+        assert_eq!(terminal_count, 1000);
     }
 }


### PR DESCRIPTION
This PR hardens the app's storage layer: schema migrations are now idempotent and persist their version per step, a corrupt SQLite file is quarantined (with an in-memory fallback) instead of crash-looping the app on every launch, the downloads table is bounded by a startup prune plus a limited active-queue query, and structured logging no longer silently drops records under contention.

## Fixes

- **Interrupted schema migration permanently bricks startup** (`src-tauri/src/ytdlp/db/mod.rs`) — all bare `ALTER TABLE` statements in v4/v5/v6 and both v7 ALTERs now go through `ensure_column`, and the schema version is persisted after each migration step; a crash or power loss mid-migration no longer leaves the app unable to ever launch again. Includes a regression test simulating an interrupted v3→v4 upgrade.
- **Corrupt ytdlp.db or logs.db causes a permanent startup crash loop** (`src-tauri/src/lib.rs`) — the two `.expect()` calls in setup are replaced by a resilient open path: corruption-class errors quarantine the db (plus its `-wal`/`-shm` siblings) to `*.corrupt-<timestamp>` and retry once, and any remaining failure falls back to an in-memory database so the app always launches instead of bricking with no message.
- **downloads table grows without bound and is full-scanned every 5s** (`src-tauri/src/ytdlp/db/queue.rs`, `src-tauri/src/lib.rs`) — startup now prunes terminal (completed/failed/cancelled) queue rows older than 30 days, and `get_active_queue` returns all active rows unbounded while capping terminal rows at the 1000 newest, so long-term users no longer suffer a progressively slower queue page or destructive-only cleanup.
- **logs.db drops records silently under contention** (`src-tauri/src/modules/log_db.rs`, `src-tauri/src/modules/logger.rs`) — `PRAGMA busy_timeout = 5000` is set on the log database, and a failed insert now prints the error plus the full dropped record (including details) to stderr and still emits the live-view event with a unique negative synthetic id, so diagnostics needed to explain failures are never lost without a trace.

## Verification

- `cargo fmt` — clean
- `cargo clippy -- -D warnings` — no warnings
- `cargo test` — 82 tests passed (including new migration and queue regression tests)
- `bun run check` (svelte-check) — no errors
- `bun run build` (vite build) — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
