### PR TITLE
fix: kill yt-dlp on exit and timeouts, add single-instance guard, stop process leaks

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -979,7 +979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3495,7 +3495,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3551,7 +3551,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4485,6 +4485,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.17",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-store"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4672,7 +4687,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5448,7 +5463,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6046,6 +6061,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-specta",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,10 @@ urlencoding = "2"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# Desktop-only: prevent a second app instance from clobbering the first one's queue DB
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-single-instance = "2"
+
 [profile.release]
 opt-level = "s"   # optimize for size; the app is I/O-bound, not CPU-bound
 lto = true        # cross-crate optimization shrinks the final binary

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,7 +87,25 @@ pub fn run() {
 
     let invoke_handler = builder.invoke_handler();
 
-    tauri::Builder::default()
+    #[allow(unused_mut)]
+    let mut tauri_builder = tauri::Builder::default();
+
+    // Single-instance must be the FIRST plugin so a second launch exits before its
+    // setup() runs reset_stale_downloads() against the first instance's live queue.
+    // The callback unhides the (possibly tray-hidden) window of the running instance.
+    #[cfg(desktop)]
+    {
+        tauri_builder =
+            tauri_builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.unminimize();
+                    let _ = window.set_focus();
+                }
+            }));
+    }
+
+    tauri_builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_store::Builder::default().build())
@@ -214,8 +232,22 @@ pub fn run() {
         .run(|app_handle, event| {
             if let tauri::RunEvent::Exit = event {
                 let manager = app_handle.state::<DownloadManagerState>();
+                let scan_manager = app_handle.state::<ScanManagerState>();
+                // Stop new work from being claimed while draining, then signal every
+                // in-flight download/scan and give their executor tasks a bounded
+                // window to run kill_process_tree (they run on tokio workers, which
+                // keep being polled while the main thread blocks here). Without the
+                // wait, the process exits before any kill runs and yt-dlp/ffmpeg
+                // survive as orphans.
+                manager.shutdown();
                 manager.cancel_all();
-                app_handle.state::<ScanManagerState>().cancel_current();
+                scan_manager.cancel_current();
+                tauri::async_runtime::block_on(async {
+                    let _ = tokio::join!(
+                        manager.wait_until_idle(std::time::Duration::from_secs(3)),
+                        scan_manager.wait_until_idle(std::time::Duration::from_secs(3)),
+                    );
+                });
             }
         });
 }

--- a/src-tauri/src/ytdlp/commands/misc.rs
+++ b/src-tauri/src/ytdlp/commands/misc.rs
@@ -25,6 +25,9 @@ pub fn set_minimize_to_tray(
         }
     } else {
         let manager = app.state::<Arc<DownloadManager>>();
+        // shutdown() stops process_next_pending from claiming the next pending row
+        // (and spawning a fresh yt-dlp) while we drain below — this path always exits.
+        manager.shutdown();
         manager.cancel_all();
         // Wait briefly for cancel signals to propagate and yt-dlp processes to terminate
         let manager_clone = manager.inner().clone();

--- a/src-tauri/src/ytdlp/download/executor.rs
+++ b/src-tauri/src/ytdlp/download/executor.rs
@@ -296,7 +296,20 @@ async fn run_download_attempt(
             match reader.read_until(b'\n', &mut buf).await {
                 Ok(0) => break, // EOF
                 Ok(_) => {}
-                Err(_) => continue, // non-fatal read error, keep going
+                // EINTR is the one realistic transient error (tokio's read_until propagates
+                // it, unlike std's). Anything else is a dead pipe — retrying busy-spins and,
+                // since this handle is awaited unbounded after child.wait(), hangs the slot.
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    logger::warn_cat(
+                        "download",
+                        &format!(
+                            "[download:{}] stdout read error, stopping reader: {}",
+                            task_id, e
+                        ),
+                    );
+                    break;
+                }
             }
             let line = String::from_utf8_lossy(&buf).trim_end().to_string();
             // Capture the resolved output file path from yt-dlp's stdout (Destination/Merger
@@ -379,7 +392,8 @@ async fn run_download_attempt(
                     let line = String::from_utf8_lossy(&buf).trim_end().to_string();
                     append_limited(&mut output, &line, STDERR_BUFFER_LIMIT_BYTES);
                 }
-                Err(_) => continue,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break, // persistent read error — no more useful data
             }
         }
         output
@@ -391,6 +405,10 @@ async fn run_download_attempt(
             match result {
                 Ok(s) => s,
                 Err(e) => {
+                    // Kill before awaiting the readers: a live child holds the pipes open,
+                    // so the unbounded awaits below would never complete — hanging this
+                    // task forever while leaking the slot and the yt-dlp process.
+                    kill_process_tree(&mut child).await;
                     let _ = stdout_handle.await;
                     let _ = stderr_handle.await;
                     return AttemptOutcome::Fatal {

--- a/src-tauri/src/ytdlp/download/manager.rs
+++ b/src-tauri/src/ytdlp/download/manager.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tokio::sync::{watch, Notify};
@@ -11,6 +11,7 @@ pub struct DownloadManager {
     max_concurrent: AtomicU32,
     cancel_senders: Mutex<HashMap<u64, watch::Sender<bool>>>,
     idle_notify: Notify,
+    shutting_down: AtomicBool,
 }
 
 impl DownloadManager {
@@ -20,7 +21,17 @@ impl DownloadManager {
             max_concurrent: AtomicU32::new(security::clamp_max_concurrent(max_concurrent)),
             cancel_senders: Mutex::new(HashMap::new()),
             idle_notify: Notify::new(),
+            shutting_down: AtomicBool::new(false),
         }
+    }
+
+    /// Mark the manager as draining for app shutdown: `try_acquire` stops handing out
+    /// slots, so a cancelled executor's `process_next_pending` cannot claim the next
+    /// pending row and spawn a fresh yt-dlp while exit paths wait for the active ones
+    /// to be killed. One-way by design — `cancel_all` alone stays reusable for the
+    /// reset/clear flows that keep the app (and queue) running afterwards.
+    pub fn shutdown(&self) {
+        self.shutting_down.store(true, Ordering::SeqCst);
     }
 
     pub fn active_count(&self) -> u32 {
@@ -45,6 +56,9 @@ impl DownloadManager {
 
     // CAS loop to fix TOCTOU race condition
     pub fn try_acquire(&self) -> bool {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return false;
+        }
         loop {
             let current = self.active_count.load(Ordering::SeqCst);
             if current >= self.max_concurrent.load(Ordering::SeqCst) {

--- a/src-tauri/src/ytdlp/metadata/mod.rs
+++ b/src-tauri/src/ytdlp/metadata/mod.rs
@@ -78,7 +78,12 @@ pub(super) async fn run_with_impersonate_fallback<F>(
 where
     F: Fn(bool) -> tokio::process::Command,
 {
-    let first = tokio::time::timeout(timeout, build_cmd(false).output())
+    // kill_on_drop: when the timeout drops the output() future, the yt-dlp child must die
+    // with it — tokio's default leaves it running (orphaned) until it next writes to the
+    // closed stdout pipe, which for --dump-json is only at the very end of extraction.
+    let mut first_cmd = build_cmd(false);
+    first_cmd.kill_on_drop(true);
+    let first = tokio::time::timeout(timeout, first_cmd.output())
         .await
         .map_err(|_| AppError::MetadataError(timeout_msg.to_string()))?
         .map_err(|e| {
@@ -95,7 +100,9 @@ where
         "metadata",
         "anti-bot block detected (410/403), retrying with --impersonate",
     );
-    let retry = tokio::time::timeout(timeout, build_cmd(true).output())
+    let mut retry_cmd = build_cmd(true);
+    retry_cmd.kill_on_drop(true);
+    let retry = tokio::time::timeout(timeout, retry_cmd.output())
         .await
         .map_err(|_| AppError::MetadataError(timeout_msg.to_string()))?
         .map_err(|e| {

--- a/src-tauri/src/ytdlp/metadata/scan.rs
+++ b/src-tauri/src/ytdlp/metadata/scan.rs
@@ -13,11 +13,12 @@ use crate::ytdlp::download::{append_limited, kill_process_tree};
 use crate::ytdlp::types::*;
 use crate::ytdlp::{binary, security};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, watch, Notify};
 
 /// Flush a batch to the frontend once it reaches this many entries…
 const SCAN_BATCH_SIZE: usize = 30;
@@ -35,11 +36,16 @@ const SCAN_STDERR_LIMIT_BYTES: usize = 64 * 1024;
 #[derive(Default)]
 pub struct ScanManager {
     current: Mutex<Option<(u32, watch::Sender<bool>)>>,
+    /// Scan tasks still running, kill/cleanup path included. `current` can't stand in for
+    /// this: the cancel paths empty the slot while the task is still killing yt-dlp.
+    active: AtomicU32,
+    idle_notify: Notify,
 }
 
 impl ScanManager {
     /// Register `scan_id` as the active scan, cancelling any previous one.
     pub fn begin(&self, scan_id: u32) -> watch::Receiver<bool> {
+        self.active.fetch_add(1, Ordering::SeqCst);
         let (tx, rx) = watch::channel(false);
         let mut current = self.current.lock().unwrap_or_else(|e| e.into_inner());
         if let Some((_, old_tx)) = current.replace((scan_id, tx)) {
@@ -73,6 +79,53 @@ impl ScanManager {
             *current = None;
         }
     }
+
+    /// Mark one scan task as fully over (kill paths included) and wake exit waiters.
+    /// Paired with `begin()` by the dispatch guard in `start_playlist_scan`, so it runs
+    /// exactly once per scan whether the task completed, was cancelled, or panicked.
+    fn release(&self) {
+        let previous = self
+            .active
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                Some(count.saturating_sub(1))
+            });
+        if matches!(previous, Ok(1)) {
+            self.idle_notify.notify_waiters();
+        }
+    }
+
+    /// Wait until no scan task is running (mirrors `DownloadManager::wait_until_idle`).
+    /// App exit paths use this so the scan's `kill_process_tree` actually gets to run
+    /// before the process dies — `cancel_current` alone only sends the signal.
+    pub async fn wait_until_idle(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+
+        // enable() registers this waiter before we read `active`, so a release() that drops
+        // the count to 0 between the check and the .await can't slip its notify past us.
+        let notified = self.idle_notify.notified();
+        tokio::pin!(notified);
+
+        loop {
+            notified.as_mut().enable();
+
+            if self.active.load(Ordering::SeqCst) == 0 {
+                return true;
+            }
+
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return false;
+            };
+
+            if tokio::time::timeout(remaining, notified.as_mut())
+                .await
+                .is_err()
+            {
+                return self.active.load(Ordering::SeqCst) == 0;
+            }
+
+            notified.set(self.idle_notify.notified());
+        }
+    }
 }
 
 /// Start a streaming playlist/channel scan. Returns immediately; entries and the terminal
@@ -98,14 +151,42 @@ pub async fn start_playlist_scan(
     let ytdlp_path = binary::resolve_ytdlp_path_with_app(&app).await?;
     let manager = app.state::<crate::ScanManagerState>().inner().clone();
     let cancel_rx = manager.begin(scan_id);
-    tauri::async_runtime::spawn(run_scan(
-        app.clone(),
-        manager,
-        scan_id,
-        url,
-        ytdlp_path,
-        cancel_rx,
-    ));
+    let scan_app = app.clone();
+    let scan_manager = manager.clone();
+    tauri::async_runtime::spawn(async move {
+        // Nested spawn + JoinError guard (same pattern as the download dispatch sites):
+        // a panic in run_scan must still emit a terminal event, or the scanning UI
+        // spins forever with the ScanManager slot left occupied.
+        let result = tokio::spawn(run_scan(
+            scan_app,
+            scan_manager,
+            scan_id,
+            url,
+            ytdlp_path,
+            cancel_rx,
+        ))
+        .await;
+        if let Err(e) = result {
+            logger::error_cat(
+                "metadata",
+                &format!("scan {}: task panicked: {:?}", scan_id, e),
+            );
+            manager.finish(scan_id);
+            emit_scan(
+                &app,
+                PlaylistScanEvent {
+                    scan_id,
+                    event_type: "error".to_string(),
+                    meta: None,
+                    entries: vec![],
+                    total: 0,
+                    message: Some("error.ytdlpGeneric".to_string()),
+                },
+            );
+        }
+        // The inner task is fully over (done, cancelled, or panicked) — kill paths included.
+        manager.release();
+    });
     Ok(())
 }
 
@@ -266,7 +347,16 @@ async fn run_scan_attempt(
                         ),
                     }
                 }
-                Err(_) => continue, // non-fatal read error, keep going
+                // EINTR is the one realistic transient error (tokio's read_until propagates
+                // it, unlike std's). Anything else is a dead pipe — retrying busy-spins.
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    logger::warn_cat(
+                        "metadata",
+                        &format!("scan stdout read error, stopping reader: {}", e),
+                    );
+                    break;
+                }
             }
         }
     });
@@ -283,7 +373,8 @@ async fn run_scan_attempt(
                     let line = String::from_utf8_lossy(&buf).trim_end().to_string();
                     append_limited(&mut output, &line, SCAN_STDERR_LIMIT_BYTES);
                 }
-                Err(_) => continue,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break, // persistent read error — no more useful data
             }
         }
         output
@@ -364,9 +455,28 @@ async fn run_scan_attempt(
     // stdout closed: collect exit status and stderr, then deliver any tail batch.
     let _ = reader_task.await;
     let status = tokio::time::timeout(Duration::from_secs(10), child.wait()).await;
+    if !matches!(&status, Ok(Ok(_))) {
+        // yt-dlp closed stdout but won't exit (hung teardown). Kill the tree BEFORE the
+        // stderr join below: SIGKILL closes the child's stderr write end, so the join hits
+        // EOF and still hands the captured buffer to map_stderr_error instead of "".
+        logger::error_cat(
+            "metadata",
+            &format!(
+                "scan {}: yt-dlp did not exit within 10s after stdout EOF, killing",
+                scan_id
+            ),
+        );
+        kill_process_tree(&mut child).await;
+    }
+    let stderr_abort = stderr_task.abort_handle();
     let stderr_output = match tokio::time::timeout(Duration::from_secs(5), stderr_task).await {
         Ok(Ok(s)) => s,
-        _ => String::new(),
+        _ => {
+            // timeout() consumed the JoinHandle; abort via the saved handle so a stuck
+            // stderr task can't keep spinning for the rest of the app's lifetime.
+            stderr_abort.abort();
+            String::new()
+        }
     };
     flush_entries(app, scan_id, &mut batch, &mut meta, &mut total);
 

--- a/src-tauri/src/ytdlp/tray.rs
+++ b/src-tauri/src/ytdlp/tray.rs
@@ -1,5 +1,6 @@
 use crate::modules::types::AppError;
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Manager};
@@ -53,9 +54,26 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             "quit" => {
-                let manager = app.state::<Arc<crate::ytdlp::download::DownloadManager>>();
+                // Stop new work, signal everything, then give the executor tasks a
+                // bounded window to run kill_process_tree before exiting — otherwise
+                // yt-dlp/ffmpeg survive the process as orphans. RunEvent::Exit waits
+                // again, but by then both managers are already idle (harmless no-op).
+                let manager = app
+                    .state::<Arc<crate::ytdlp::download::DownloadManager>>()
+                    .inner()
+                    .clone();
+                let scan_manager = app.state::<crate::ScanManagerState>().inner().clone();
+                manager.shutdown();
                 manager.cancel_all();
-                app.exit(0);
+                scan_manager.cancel_current();
+                let app = app.clone();
+                tauri::async_runtime::spawn(async move {
+                    let _ = tokio::join!(
+                        manager.wait_until_idle(Duration::from_secs(3)),
+                        scan_manager.wait_until_idle(Duration::from_secs(3)),
+                    );
+                    app.exit(0);
+                });
             }
             _ => {}
         })

--- a/src/routes/tools/ytdlp/+layout.svelte
+++ b/src/routes/tools/ytdlp/+layout.svelte
@@ -125,6 +125,12 @@
 
   async function handleCloseBlockedExit() {
     showCloseBlockedDialog = false
+    // Cancel active downloads first so their rows persist as "cancelled" instead of
+    // being mislabeled "failed" on next launch. The backend RunEvent::Exit handler
+    // then waits (bounded) for the yt-dlp processes to actually be killed.
+    try {
+      await commands.cancelAllDownloads()
+    } catch (e) { console.error("Failed to cancel downloads:", e) }
     try {
       await exit(0)
     } catch (e) { console.error("Failed to exit:", e) }


### PR DESCRIPTION
This PR hardens the process lifecycle so the app never orphans yt-dlp/ffmpeg/deno processes — on app exit, on metadata fetch timeouts, and during playlist-scan teardown — and prevents a second app instance from corrupting the first instance's download queue. A new shutdown flag on `DownloadManager` stops the queue from respawning work while the app drains, exit paths now wait (bounded ~3s) for both downloads and scans to finish their kill paths, timed-out child processes are killed instead of dropped alive, and `tauri-plugin-single-instance` focuses the existing window instead of letting a duplicate process flip live downloads to "failed".

## Fixes

- **App exit waits for executors to kill yt-dlp** (`download-lifecycle#0`) — `src-tauri/src/lib.rs`, `src-tauri/src/ytdlp/download/manager.rs`: quitting mid-download no longer leaves yt-dlp/ffmpeg running invisibly; `RunEvent::Exit` sets the new `DownloadManager::shutdown()` flag (checked in `try_acquire`, which also closes the `process_next_pending` respawn hole), cancels all, then blocks on a bounded `wait_until_idle` so kill paths and "cancelled" DB writes actually run before the process dies.
- **Tray Quit and "Exit anyway" no longer orphan processes** (`process-cancel#0`) — `src-tauri/src/ytdlp/tray.rs`, `src-tauri/src/ytdlp/commands/misc.rs`, `src/routes/tools/ytdlp/+layout.svelte`: tray Quit now sets shutdown, cancels downloads and scans, and waits in a spawned task before `app.exit(0)`; the frontend "Exit anyway" button awaits `cancelAllDownloads()` before `exit(0)`, so active rows persist as "cancelled" instead of being mislabeled "failed" on next launch.
- **Single-instance guard** (`download-lifecycle#5`) — `src-tauri/src/lib.rs`, `src-tauri/Cargo.toml`: launching the app twice on Windows/Linux no longer flips the first instance's in-progress downloads to "failed (App closed during download)"; `tauri-plugin-single-instance` is registered as the first builder plugin (desktop-gated) and its callback shows, unminimizes, and focuses the existing window (covers the tray-hidden case).
- **No more dueling instances on the same queue DB** (`db-integrity#1`) — `src-tauri/src/lib.rs`: the second instance exits before its startup `reset_stale_downloads()`/`process_next_pending` can corrupt rows or double-dispatch the same download into two yt-dlp processes writing the same `.part` file.
- **Metadata fetch timeout kills the child** (`process-cancel#1`) — `src-tauri/src/ytdlp/metadata/mod.rs`: a timed-out URL analysis no longer leaks a full yt-dlp Python process; `run_with_impersonate_fallback` sets `kill_on_drop(true)` so the timeout actually terminates the child for all callers.
- **Both fallback attempts covered** (`metadata-scan#2`) — `src-tauri/src/ytdlp/metadata/mod.rs`: `kill_on_drop(true)` is applied inside the helper to the first attempt and the impersonate retry, so retry-stacked orphans (each re-copying the browser cookie DB) can no longer accumulate.
- **Scan wait-timeout kills the process tree and keeps the real error** (`process-cancel#2`) — `src-tauri/src/ytdlp/metadata/scan.rs`, `src-tauri/src/ytdlp/download/executor.rs`: when `child.wait()` times out after stdout EOF, the scan now calls `kill_process_tree` before the stderr join so stderr reaches EOF and `map_stderr_error` reports the actual failure instead of a generic "yt-dlp error"; the executor's `wait()` Err arm also kills the tree before awaiting the (previously unbounded) reader handles.
- **Scan no longer leaks yt-dlp on hung teardown** (`metadata-scan#4`) — `src-tauri/src/ytdlp/metadata/scan.rs`: a yt-dlp that closes stdout but hangs in cleanup is killed instead of dropped alive, and the stderr task is aborted via a saved `abort_handle` if its join times out.
- **Reader tasks stop busy-spinning on persistent pipe errors** (`metadata-scan#7`) — `src-tauri/src/ytdlp/metadata/scan.rs`, `src-tauri/src/ytdlp/download/executor.rs`: all four stdout/stderr reader `Err` arms now break on persistent read errors (retaining `ErrorKind::Interrupted => continue` for EINTR), so a broken pipe can no longer peg a CPU core indefinitely or hang a download while leaking a concurrency slot.
- **Playlist scan dispatch gets a panic guard** (`process-cancel#5`) — `src-tauri/src/ytdlp/metadata/scan.rs`: if the scan task panics, the guard calls `manager.finish(scan_id)`, releases the new idle signal, logs the JoinError, and emits a terminal `error` PlaylistScanEvent (`error.ytdlpGeneric`), so the analysis UI can never spin forever in a silent stuck state. The `ScanManager` also gains an `AtomicU32` + `Notify` based `wait_until_idle()` so exit paths cover scans, awaited concurrently with the download wait via `tokio::join!` (total bounded wait ~3s).

## Verification

- `cargo fmt` — clean
- `cargo clippy -- -D warnings` — no warnings
- `cargo test` — all tests pass (79+ tests)
- `bun run check` (svelte-check) — no errors
- `bun run build` (vite build) — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
