### PR TITLE
fix: classify yt-dlp failures correctly and localize stored error messages

### DIFF
--- a/src-tauri/src/ytdlp/db/queue.rs
+++ b/src-tauri/src/ytdlp/db/queue.rs
@@ -322,7 +322,7 @@ impl Database {
         let conn = self.conn();
         let rows = conn
             .execute(
-                "UPDATE downloads SET status = 'failed', error_message = 'App closed during download' WHERE status = 'downloading'",
+                "UPDATE downloads SET status = 'failed', error_message = 'error.appClosedDuringDownload' WHERE status = 'downloading'",
                 [],
             )
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;

--- a/src-tauri/src/ytdlp/download/executor.rs
+++ b/src-tauri/src/ytdlp/download/executor.rs
@@ -65,17 +65,30 @@ fn emit_download_error(app: &AppHandle, task_id: u64, message: String, detail: O
 }
 
 /// Helper: handle a fatal download error by logging, updating DB, emitting event,
-/// and releasing the slot.
+/// and releasing the slot. `error_msg` must be a stable i18n key (the queue UI runs it
+/// through t()); the dynamic cause goes in `detail`, which is sanitized before persisting
+/// because the queue page renders error_detail verbatim, without translation.
 fn handle_download_failure(
     app: &AppHandle,
     task_id: u64,
     error_msg: &str,
+    detail: Option<&str>,
     db: &crate::DbState,
     manager: &Arc<DownloadManager>,
 ) {
-    logger::error_cat("download", &format!("[download:{}] {}", task_id, error_msg));
-    let _ = db.update_download_status(task_id, &DownloadStatus::Failed, Some(error_msg), None);
-    emit_download_error(app, task_id, error_msg.to_string(), None);
+    let log_line = match detail {
+        Some(d) => format!("[download:{}] {}: {}", task_id, error_msg, d),
+        None => format!("[download:{}] {}", task_id, error_msg),
+    };
+    logger::error_cat("download", &log_line);
+    let detail = detail.map(security::sanitize_error_message);
+    let _ = db.update_download_status(
+        task_id,
+        &DownloadStatus::Failed,
+        Some(error_msg),
+        detail.as_deref(),
+    );
+    emit_download_error(app, task_id, error_msg.to_string(), detail);
     manager.unregister_cancel(task_id);
     manager.release();
     process_next_pending(app.clone());
@@ -136,23 +149,47 @@ fn is_resolved_path(path: Option<&str>) -> bool {
     matches!(path, Some(p) if !p.is_empty() && !p.contains("%("))
 }
 
+/// Static directory prefix of an output template: every path component before the first one
+/// containing a `%(` placeholder. Splitting the raw string at `%(` would truncate mid-component
+/// for templates like `prefix%(title)s.%(ext)s`. A template with no placeholders at all is a
+/// concrete file path, so its parent directory is the prefix.
+pub(super) fn static_template_prefix(output_path: &str) -> std::path::PathBuf {
+    let path = std::path::Path::new(output_path);
+    let mut prefix = std::path::PathBuf::new();
+    for component in path.components() {
+        if component.as_os_str().to_string_lossy().contains("%(") {
+            return prefix;
+        }
+        prefix.push(component);
+    }
+    path.parent().map(|p| p.to_path_buf()).unwrap_or_default()
+}
+
 /// Map a finished yt-dlp process's exit code + stderr to a stable i18n error key.
 /// Extracted as a pure function so the classification (cookie failures, network errors,
 /// Windows cp949 encoding crashes) is testable. The frontend translates the key; the raw
 /// stderr is logged separately, so it isn't embedded in the user-facing message anymore.
 pub(super) fn classify_download_error(code: Option<i32>, stderr_output: &str) -> String {
+    // "Could not copy" = cookie DB locked by a running browser; "cookies database" = yt-dlp's
+    // lowercase "could not find <browser> cookies database in ..." when the configured browser
+    // is uninstalled or its profile is unreadable (e.g. Safari without Full Disk Access).
+    let is_cookie_error = (stderr_output.contains("Could not copy")
+        && stderr_output.contains("cookie"))
+        || stderr_output.contains("cookies database");
     let Some(code) = code else {
         return "error.processTerminated".to_string();
     };
     match code {
         1 => {
-            if stderr_output.contains("Could not copy") && stderr_output.contains("cookie") {
+            if is_cookie_error {
                 "error.cookieAccess".to_string()
             } else {
                 "error.downloadFailed".to_string()
             }
         }
-        2 => "error.networkError".to_string(),
+        // yt-dlp reserves exit code 2 for invalid user-provided options (optparse), e.g. an
+        // outdated binary rejecting a flag. Network failures exit 1, not 2.
+        2 => "error.invalidOptions".to_string(),
         120 => {
             let is_encoding_error = stderr_output.contains("cp949")
                 || stderr_output.contains("cp932")
@@ -165,18 +202,31 @@ pub(super) fn classify_download_error(code: Option<i32>, stderr_output: &str) ->
                 "error.downloadFailed".to_string()
             }
         }
-        _ => "error.downloadFailed".to_string(),
+        _ => {
+            if is_cookie_error {
+                "error.cookieAccess".to_string()
+            } else {
+                "error.downloadFailed".to_string()
+            }
+        }
     }
 }
 
 /// Pull the most informative raw line out of yt-dlp's stderr so the UI can show the real cause
 /// (e.g. "ERROR: Postprocessing: Error opening output files: Encoder not found") alongside the
-/// generic classified key. Returns the last `ERROR:`-tagged line, or None when there is none.
+/// generic classified key. Returns the last `ERROR:`-tagged line, falling back to the lowercase
+/// optparse form ("yt-dlp: error: no such option: ..."), or None when neither is present.
 pub(super) fn extract_ytdlp_error(stderr: &str) -> Option<String> {
     stderr
         .lines()
         .map(str::trim)
         .rfind(|line| line.contains("ERROR:"))
+        .or_else(|| {
+            stderr
+                .lines()
+                .map(str::trim)
+                .rfind(|line| line.contains("yt-dlp: error:"))
+        })
         .map(str::to_string)
 }
 
@@ -484,19 +534,21 @@ pub(super) async fn execute_download(app: AppHandle, task_id: u64) {
 
     let ytdlp_path = match binary::resolve_ytdlp_path_with_app(&app).await {
         Ok(p) => p,
-        Err(_e) => {
-            let error_msg = "yt-dlp not found. Please install via Homebrew or click Install.";
+        Err(e) => {
+            // Same i18n key in the DB row and the emitted event so both surfaces agree.
+            let error_msg = "error.ytdlpNotFound";
             logger::error_cat(
                 "download",
-                &format!("[download:{}] yt-dlp not found: {}", task_id, _e),
+                &format!("[download:{}] yt-dlp not found: {}", task_id, e),
             );
+            let detail = security::sanitize_error_message(&e.to_string());
             let _ = db_state.update_download_status(
                 task_id,
                 &DownloadStatus::Failed,
                 Some(error_msg),
-                None,
+                Some(&detail),
             );
-            emit_download_error(&app, task_id, "yt-dlp not found".to_string(), None);
+            emit_download_error(&app, task_id, error_msg.to_string(), Some(detail));
             manager.unregister_cancel(task_id);
             manager.release();
             process_next_pending(app);
@@ -507,12 +559,15 @@ pub(super) async fn execute_download(app: AppHandle, task_id: u64) {
     let settings = match settings::get_settings(&app) {
         Ok(s) => s,
         Err(e) => {
-            logger::error_cat(
-                "download",
-                &format!("[download:{}] failed to get settings: {}", task_id, e),
+            let detail = format!("Failed to load settings: {}", e);
+            handle_download_failure(
+                &app,
+                task_id,
+                "error.downloadFailed",
+                Some(&detail),
+                &db_state,
+                &manager,
             );
-            let error_msg = format!("Failed to load settings: {}", e);
-            handle_download_failure(&app, task_id, &error_msg, &db_state, &manager);
             return;
         }
     };
@@ -545,7 +600,8 @@ pub(super) async fn execute_download(app: AppHandle, task_id: u64) {
             handle_download_failure(
                 &app,
                 task_id,
-                &format!("invalid format selector: {}", e),
+                "error.downloadFailed",
+                Some(&format!("invalid format selector: {}", e)),
                 &db_state,
                 &manager,
             );
@@ -559,7 +615,8 @@ pub(super) async fn execute_download(app: AppHandle, task_id: u64) {
                 handle_download_failure(
                     &app,
                     task_id,
-                    &format!("invalid audio format: {}", e),
+                    "error.downloadFailed",
+                    Some(&format!("invalid audio format: {}", e)),
                     &db_state,
                     &manager,
                 );
@@ -575,7 +632,8 @@ pub(super) async fn execute_download(app: AppHandle, task_id: u64) {
                 handle_download_failure(
                     &app,
                     task_id,
-                    &format!("invalid audio quality: {}", e),
+                    "error.downloadFailed",
+                    Some(&format!("invalid audio quality: {}", e)),
                     &db_state,
                     &manager,
                 );
@@ -584,6 +642,24 @@ pub(super) async fn execute_download(app: AppHandle, task_id: u64) {
         },
         None => None,
     };
+
+    // Preflight the download directory: if the configured folder lives on a disconnected
+    // volume or offline network share, fail fast with a clear, retryable reason instead of
+    // letting yt-dlp die with a generic exit-1 for every queued item.
+    let static_dir = static_template_prefix(&task.output_path);
+    if !static_dir.as_os_str().is_empty() {
+        if let Err(e) = tokio::fs::create_dir_all(&static_dir).await {
+            handle_download_failure(
+                &app,
+                task_id,
+                "error.downloadPathUnavailable",
+                Some(&format!("{}: {}", static_dir.display(), e)),
+                &db_state,
+                &manager,
+            );
+            return;
+        }
+    }
 
     // Build yt-dlp args in a Vec for logging before passing to Command
     let mut args: Vec<String> = Vec::new();
@@ -666,8 +742,14 @@ pub(super) async fn execute_download(app: AppHandle, task_id: u64) {
 
     // Anti-bot (410/403) auto-fallback: retry once with --impersonate. The block happens during
     // extraction before any file is written, and --no-overwrites keeps the retry safe.
-    if let AttemptOutcome::Failed { stderr, .. } = &outcome {
-        if crate::ytdlp::metadata::looks_like_antibot_block(stderr) {
+    if let AttemptOutcome::Failed {
+        code: first_code,
+        stderr: first_stderr,
+    } = &outcome
+    {
+        if crate::ytdlp::metadata::looks_like_antibot_block(first_stderr) {
+            let first_code = *first_code;
+            let first_stderr = first_stderr.clone();
             logger::warn_cat(
                 "download",
                 &format!(
@@ -684,6 +766,30 @@ pub(super) async fn execute_download(app: AppHandle, task_id: u64) {
                 crate::ytdlp::metadata::IMPERSONATE_TARGET.to_string(),
             );
             outcome = run_download_attempt(&app, task_id, &ytdlp_path, &args, &mut cancel_rx).await;
+
+            // If the retry only proved that this yt-dlp doesn't know --impersonate (optparse
+            // exits 2 with lowercase "yt-dlp: error: no such option"), classifying it would
+            // report the wrong cause. Keep attempt 1's real outcome and append the optparse
+            // line so the outdated binary is still visible in the logged stderr.
+            if let AttemptOutcome::Failed { code, stderr } = &outcome {
+                if *code == Some(2) || stderr.contains("no such option") {
+                    logger::warn_cat(
+                        "download",
+                        &format!(
+                            "[download:{}] --impersonate unsupported by this yt-dlp (update it); keeping first attempt's failure",
+                            task_id
+                        ),
+                    );
+                    let combined = match extract_ytdlp_error(stderr) {
+                        Some(line) => format!("{}\n{}", first_stderr, line),
+                        None => first_stderr,
+                    };
+                    outcome = AttemptOutcome::Failed {
+                        code: first_code,
+                        stderr: combined,
+                    };
+                }
+            }
         }
     }
 
@@ -847,7 +953,14 @@ pub(super) async fn execute_download(app: AppHandle, task_id: u64) {
         }
         AttemptOutcome::Fatal { msg } => {
             // handle_download_failure already releases the slot and dispatches the next task.
-            handle_download_failure(&app, task_id, &msg, &db_state, &manager);
+            handle_download_failure(
+                &app,
+                task_id,
+                "error.downloadFailed",
+                Some(&msg),
+                &db_state,
+                &manager,
+            );
             return;
         }
     }
@@ -966,9 +1079,27 @@ mod tests {
     }
 
     #[test]
-    fn classify_network_error_on_code_2() {
-        let msg = classify_download_error(Some(2), "unable to resolve host");
-        assert_eq!(msg, "error.networkError");
+    fn classify_invalid_options_on_code_2() {
+        // yt-dlp reserves exit code 2 for optparse failures (e.g. an outdated binary
+        // rejecting --impersonate); network errors raise DownloadError and exit 1.
+        let msg = classify_download_error(Some(2), "yt-dlp: error: no such option: --impersonate");
+        assert_eq!(msg, "error.invalidOptions");
+    }
+
+    #[test]
+    fn classify_missing_cookies_database_on_code_1() {
+        let msg = classify_download_error(
+            Some(1),
+            "ERROR: could not find chrome cookies database in \"~/Library/Application Support/Google/Chrome\"",
+        );
+        assert_eq!(msg, "error.cookieAccess");
+    }
+
+    #[test]
+    fn classify_missing_cookies_database_on_unknown_code() {
+        let msg =
+            classify_download_error(Some(99), "ERROR: could not find firefox cookies database");
+        assert_eq!(msg, "error.cookieAccess");
     }
 
     #[test]
@@ -1010,6 +1141,50 @@ mod tests {
         assert_eq!(
             extract_ytdlp_error("[download] just progress\nfinished"),
             None
+        );
+    }
+
+    #[test]
+    fn extract_ytdlp_error_falls_back_to_optparse_line() {
+        let stderr = "Usage: yt-dlp [OPTIONS] URL\n\nyt-dlp: error: no such option: --impersonate";
+        assert_eq!(
+            extract_ytdlp_error(stderr).as_deref(),
+            Some("yt-dlp: error: no such option: --impersonate")
+        );
+    }
+
+    #[test]
+    fn extract_ytdlp_error_prefers_uppercase_error_line() {
+        let stderr =
+            "ERROR: HTTP Error 403: Forbidden\nyt-dlp: error: no such option: --impersonate";
+        assert_eq!(
+            extract_ytdlp_error(stderr).as_deref(),
+            Some("ERROR: HTTP Error 403: Forbidden")
+        );
+    }
+
+    #[test]
+    fn static_prefix_stops_before_placeholder_component() {
+        assert_eq!(
+            static_template_prefix("/Users/me/Downloads/%(title)s.%(ext)s"),
+            std::path::PathBuf::from("/Users/me/Downloads")
+        );
+        // The placeholder can start mid-component; a raw split at "%(" would keep "prefix".
+        assert_eq!(
+            static_template_prefix("/Users/me/Downloads/prefix%(title)s.%(ext)s"),
+            std::path::PathBuf::from("/Users/me/Downloads")
+        );
+        assert_eq!(
+            static_template_prefix("/Users/me/Downloads/%(uploader)s/%(title)s.%(ext)s"),
+            std::path::PathBuf::from("/Users/me/Downloads")
+        );
+    }
+
+    #[test]
+    fn static_prefix_of_concrete_path_is_its_parent() {
+        assert_eq!(
+            static_template_prefix("/Users/me/Downloads/video.mp4"),
+            std::path::PathBuf::from("/Users/me/Downloads")
         );
     }
 }

--- a/src-tauri/src/ytdlp/metadata/fetch.rs
+++ b/src-tauri/src/ytdlp/metadata/fetch.rs
@@ -59,18 +59,35 @@ pub async fn fetch_video_info(app: AppHandle, url: String) -> Result<VideoInfo, 
 
     // Parse JSON output
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let json: serde_json::Value = serde_json::from_str(&stdout)
-        .map_err(|e| AppError::MetadataError(format!("Failed to parse JSON: {}", e)))?;
+    let json: serde_json::Value = serde_json::from_str(&stdout).map_err(|e| {
+        logger::error_cat(
+            "metadata",
+            &format!(
+                "fetch_video_info: failed to parse yt-dlp JSON: {}",
+                security::sanitize_error_message(&e.to_string())
+            ),
+        );
+        AppError::MetadataError("error.ytdlpGeneric".to_string())
+    })?;
 
     // Extract video info
     let video_id = json["id"]
         .as_str()
-        .ok_or_else(|| AppError::MetadataError("Missing video id".to_string()))?
+        .ok_or_else(|| {
+            logger::error_cat(
+                "metadata",
+                "fetch_video_info: missing video id in yt-dlp JSON",
+            );
+            AppError::MetadataError("error.ytdlpGeneric".to_string())
+        })?
         .to_string();
 
     let title = json["title"]
         .as_str()
-        .ok_or_else(|| AppError::MetadataError("Missing title".to_string()))?
+        .ok_or_else(|| {
+            logger::error_cat("metadata", "fetch_video_info: missing title in yt-dlp JSON");
+            AppError::MetadataError("error.ytdlpGeneric".to_string())
+        })?
         .to_string();
 
     let thumbnail = json["thumbnail"].as_str().unwrap_or("").to_string();
@@ -98,7 +115,13 @@ pub async fn fetch_video_info(app: AppHandle, url: String) -> Result<VideoInfo, 
     // Extract formats
     let formats = json["formats"]
         .as_array()
-        .ok_or_else(|| AppError::MetadataError("Missing formats array".to_string()))?
+        .ok_or_else(|| {
+            logger::error_cat(
+                "metadata",
+                "fetch_video_info: missing formats array in yt-dlp JSON",
+            );
+            AppError::MetadataError("error.noFormats".to_string())
+        })?
         .iter()
         .filter_map(|format| {
             let format_id = format["format_id"].as_str()?.to_string();
@@ -383,8 +406,16 @@ pub async fn detect_url_type(app: AppHandle, url: String) -> Result<UrlType, App
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let json: serde_json::Value = serde_json::from_str(stdout.trim())
-        .map_err(|e| AppError::MetadataError(format!("Failed to parse JSON: {}", e)))?;
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).map_err(|e| {
+        logger::error_cat(
+            "metadata",
+            &format!(
+                "detect_url_type: failed to parse yt-dlp JSON: {}",
+                security::sanitize_error_message(&e.to_string())
+            ),
+        );
+        AppError::MetadataError("error.ytdlpGeneric".to_string())
+    })?;
 
     let url_type = match json["_type"].as_str() {
         Some("playlist") | Some("multi_video") => UrlType::Playlist,

--- a/src-tauri/src/ytdlp/metadata/mod.rs
+++ b/src-tauri/src/ytdlp/metadata/mod.rs
@@ -15,29 +15,10 @@ pub use validation::*;
 /// user's current UI language (see `extractError` + `src/lib/i18n/locales`). The raw stderr is
 /// logged by the caller, so messages stay clean and fully localized for every language.
 fn map_stderr_error(stderr: &str) -> AppError {
-    if stderr.contains("Private video") || stderr.contains("Sign in") {
-        return AppError::MetadataError("error.privateVideo".to_string());
-    }
-    if stderr.contains("Video unavailable") || stderr.contains("not available") {
-        return AppError::MetadataError("error.videoUnavailable".to_string());
-    }
-    if stderr.contains("is not a valid URL") || stderr.contains("Unsupported URL") {
-        return AppError::InvalidUrl("error.unsupportedUrl".to_string());
-    }
-    if stderr.contains("HTTP Error 429") || stderr.contains("Too Many Requests") {
-        return AppError::NetworkError("error.tooManyRequests".to_string());
-    }
-    // 410이 여기까지 왔다는 건 --impersonate 자동 재시도(run_with_impersonate_fallback)에도
-    // 여전히 차단됐다는 뜻이다.
-    if stderr.contains("HTTP Error 410") || stderr.contains(": Gone") {
-        return AppError::MetadataError("error.siteBlocked".to_string());
-    }
-    if stderr.contains("No video formats found") {
-        return AppError::MetadataError("error.noFormats".to_string());
-    }
-    // Match specific age-restriction phrases only. A bare "age" substring also matches the
-    // very common "Unable to download webpage" error, mislabeling network failures as
-    // age-restricted content.
+    // Match specific age-restriction phrases only, and BEFORE any "Sign in" handling: the real
+    // YouTube age gate is "Sign in to confirm your age. This video may be inappropriate for
+    // some users." A bare "age" substring also matches the very common "Unable to download
+    // webpage" error, mislabeling network failures as age-restricted content.
     if stderr.contains("confirm your age")
         || stderr.contains("age-restricted")
         || stderr.contains("age restricted")
@@ -45,8 +26,54 @@ fn map_stderr_error(stderr: &str) -> AppError {
     {
         return AppError::MetadataError("error.ageRestricted".to_string());
     }
-    if stderr.contains("Could not copy") && stderr.contains("cookie") {
+    // YouTube anti-bot check: "Sign in to confirm you're not a bot. Use --cookies-from-browser
+    // ...". Matching "not a bot" sidesteps the apostrophe variants (you're / you’re).
+    if stderr.contains("not a bot") {
+        return AppError::MetadataError("error.botCheck".to_string());
+    }
+    if stderr.contains("Private video") {
+        return AppError::MetadataError("error.privateVideo".to_string());
+    }
+    // The --impersonate retry against a yt-dlp built without curl_cffi fails with
+    // 'Impersonate target "chrome" is not available' — match it before the broad
+    // "not available" branch below so a live video isn't reported as unavailable.
+    if stderr.contains("Impersonate target") || stderr.contains("curl_cffi") {
+        return AppError::MetadataError("error.impersonateUnavailable".to_string());
+    }
+    if stderr.contains("Video unavailable") || stderr.contains("not available") {
+        return AppError::MetadataError("error.videoUnavailable".to_string());
+    }
+    if stderr.contains("is not a valid URL") || stderr.contains("Unsupported URL") {
+        return AppError::InvalidUrl("error.unsupportedUrl".to_string());
+    }
+    // 429 must stay before the 403 branch: rate limiting isn't fixable with cookies.
+    if stderr.contains("HTTP Error 429") || stderr.contains("Too Many Requests") {
+        return AppError::NetworkError("error.tooManyRequests".to_string());
+    }
+    // 410/403이 여기까지 왔다는 건 --impersonate 자동 재시도(run_with_impersonate_fallback)에도
+    // 여전히 차단됐다는 뜻이다.
+    if stderr.contains("HTTP Error 410")
+        || stderr.contains(": Gone")
+        || stderr.contains("HTTP Error 403")
+        || stderr.contains("Forbidden")
+    {
+        return AppError::MetadataError("error.siteBlocked".to_string());
+    }
+    if stderr.contains("No video formats found") {
+        return AppError::MetadataError("error.noFormats".to_string());
+    }
+    // "Could not copy" = cookie DB locked by a running browser; "cookies database" = yt-dlp's
+    // lowercase "could not find <browser> cookies database in ..." for an uninstalled browser
+    // or an unreadable profile (e.g. Safari without Full Disk Access).
+    if (stderr.contains("Could not copy") && stderr.contains("cookie"))
+        || stderr.contains("cookies database")
+    {
         return AppError::MetadataError("error.cookieAccess".to_string());
+    }
+    // Late catch-all: nearly every remaining "Sign in ..." yt-dlp error is cookie-fixable, so
+    // keep the coverage the old broad "Sign in" branch had, just with an accurate label.
+    if stderr.contains("Sign in") {
+        return AppError::MetadataError("error.botCheck".to_string());
     }
 
     AppError::MetadataError("error.ytdlpGeneric".to_string())
@@ -107,7 +134,89 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::looks_like_antibot_block;
+    use super::{looks_like_antibot_block, map_stderr_error};
+    use crate::modules::types::AppError;
+
+    fn key(stderr: &str) -> String {
+        match map_stderr_error(stderr) {
+            AppError::MetadataError(k) | AppError::InvalidUrl(k) | AppError::NetworkError(k) => k,
+            other => panic!("unexpected error variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bot_check_wins_over_private_video() {
+        // Real YouTube anti-bot message (the dominant failure since 2024).
+        assert_eq!(
+            key("ERROR: [youtube] dQw4w9WgXcQ: Sign in to confirm you're not a bot. Use --cookies-from-browser or --cookies for the authentication."),
+            "error.botCheck"
+        );
+    }
+
+    #[test]
+    fn age_gate_wins_over_sign_in() {
+        // Real YouTube age-gate message also starts with "Sign in".
+        assert_eq!(
+            key("ERROR: [youtube] abc: Sign in to confirm your age. This video may be inappropriate for some users."),
+            "error.ageRestricted"
+        );
+    }
+
+    #[test]
+    fn private_video_still_matches() {
+        assert_eq!(
+            key("ERROR: [youtube] abc: Private video. Sign in if you've been granted access to this video"),
+            "error.privateVideo"
+        );
+    }
+
+    #[test]
+    fn bare_sign_in_falls_back_to_bot_check() {
+        assert_eq!(
+            key("ERROR: [youtube] abc: Sign in to view this content"),
+            "error.botCheck"
+        );
+    }
+
+    #[test]
+    fn impersonate_target_not_available_is_not_video_unavailable() {
+        assert_eq!(
+            key("ERROR: Impersonate target \"chrome\" is not available. You may be missing dependencies required to support this target."),
+            "error.impersonateUnavailable"
+        );
+    }
+
+    #[test]
+    fn geo_block_still_maps_to_video_unavailable() {
+        assert_eq!(
+            key("ERROR: [youtube] abc: This video is not available in your country"),
+            "error.videoUnavailable"
+        );
+    }
+
+    #[test]
+    fn persistent_403_maps_to_site_blocked() {
+        assert_eq!(
+            key("ERROR: unable to download video data: HTTP Error 403: Forbidden"),
+            "error.siteBlocked"
+        );
+    }
+
+    #[test]
+    fn rate_limit_stays_too_many_requests() {
+        assert_eq!(
+            key("ERROR: HTTP Error 429: Too Many Requests"),
+            "error.tooManyRequests"
+        );
+    }
+
+    #[test]
+    fn missing_cookies_database_maps_to_cookie_access() {
+        assert_eq!(
+            key("ERROR: could not find chrome cookies database in \"~/Library/Application Support/Google/Chrome\""),
+            "error.cookieAccess"
+        );
+    }
 
     #[test]
     fn antibot_block_detects_410_and_403() {

--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -264,10 +264,10 @@ const de: Record<string, string> = {
   "error.videoUnavailable": "Dieses Video ist nicht verfügbar.",
   "error.unsupportedUrl": "Nicht unterstütztes URL-Format.",
   "error.tooManyRequests": "Zu viele Anfragen. Bitte versuchen Sie es in Kürze erneut.",
-  "error.siteBlocked": "Die Website hat die Anfrage blockiert (HTTP 410). Der Browser-Imitationsversuch ist ebenfalls fehlgeschlagen. Versuchen Sie es später erneut oder aktualisieren Sie yt-dlp / konfigurieren Sie Cookies.",
+  "error.siteBlocked": "Die Website hat die Anfrage blockiert (HTTP 410/403). Der Browser-Imitationsversuch ist ebenfalls fehlgeschlagen. Versuchen Sie es später erneut oder aktualisieren Sie yt-dlp / konfigurieren Sie Cookies.",
   "error.noFormats": "Keine Videoformate gefunden. Möglicherweise ein Livestream.",
   "error.ageRestricted": "Altersbeschränkter Inhalt. Legen Sie in den Einstellungen einen Cookie-Browser fest.",
-  "error.cookieAccess": "Kein Zugriff auf Browser-Cookies. Beenden Sie den Browser vollständig oder verwenden Sie Firefox-Cookies.",
+  "error.cookieAccess": "Kein Zugriff auf Browser-Cookies. Beenden Sie den Browser vollständig oder ändern/entfernen Sie den Cookie-Browser in den Einstellungen.",
   "error.ytdlpGeneric": "Videoinformationen konnten nicht abgerufen werden.",
   "error.ytdlpExecFailed": "yt-dlp konnte nicht ausgeführt werden.",
   "error.fetchTimeout": "Zeitüberschreitung der Anfrage. Überprüfen Sie Ihre Netzwerkverbindung.",
@@ -311,6 +311,15 @@ const de: Record<string, string> = {
   // Added: history actions
   "history.revealInFolder": "Im Ordner anzeigen",
   "history.deleteItem": "Löschen",
+
+  // Added: error classification & i18n fixes
+  "error.botCheck": "YouTube hat die Anfrage als automatisierten Zugriff eingestuft (Bot-Prüfung). Legen Sie in den Einstellungen einen Cookie-Browser fest, um angemeldet zuzugreifen.",
+  "error.impersonateUnavailable": "Dieses yt-dlp kann keinen Browser imitieren (curl_cffi fehlt). Aktualisieren oder installieren Sie yt-dlp in den Einstellungen neu und versuchen Sie es erneut.",
+  "error.invalidOptions": "yt-dlp hat die Download-Optionen abgelehnt. Ihr yt-dlp ist möglicherweise veraltet – aktualisieren Sie es in den Einstellungen.",
+  "error.ytdlpNotFound": "yt-dlp wurde nicht gefunden. Installieren Sie es unter Einstellungen → Abhängigkeiten.",
+  "error.appClosedDuringDownload": "Die App wurde geschlossen, während dieser Download lief.",
+  "error.downloadPathUnavailable": "Der Download-Ordner ist nicht verfügbar (Laufwerk getrennt oder Ordner kann nicht erstellt werden). Prüfen Sie den Download-Pfad in den Einstellungen und versuchen Sie es erneut.",
+  "settings.cookieBrowserMissing": "{browser} (nicht erkannt)",
 }
 
 export default de

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -272,10 +272,10 @@ const en: Record<string, string> = {
   "error.videoUnavailable": "This video is unavailable.",
   "error.unsupportedUrl": "Unsupported URL format.",
   "error.tooManyRequests": "Too many requests. Please try again shortly.",
-  "error.siteBlocked": "The site blocked the request (HTTP 410). Browser impersonation retry also failed. Try again later, or update yt-dlp / configure cookies.",
+  "error.siteBlocked": "The site blocked the request (HTTP 410/403). Browser impersonation retry also failed. Try again later, or update yt-dlp / configure cookies.",
   "error.noFormats": "No video formats found. This may be a live stream.",
   "error.ageRestricted": "Age-restricted content. Set a cookie browser in Settings.",
-  "error.cookieAccess": "Can't access browser cookies. Fully quit the browser, or use Firefox cookies.",
+  "error.cookieAccess": "Can't access browser cookies. Fully quit the browser, or change/clear the cookie browser in Settings.",
   "error.ytdlpGeneric": "Failed to fetch video info.",
   "error.ytdlpExecFailed": "Failed to run yt-dlp.",
   "error.fetchTimeout": "The request timed out. Check your network connection.",
@@ -319,6 +319,15 @@ const en: Record<string, string> = {
   // Added: history actions
   "history.revealInFolder": "Show in folder",
   "history.deleteItem": "Delete",
+
+  // Added: error classification & i18n fixes
+  "error.botCheck": "YouTube flagged this as automated traffic (bot check). Set a cookie browser in Settings to access it signed in.",
+  "error.impersonateUnavailable": "This yt-dlp can't impersonate a browser (curl_cffi missing). Update or reinstall yt-dlp in Settings and try again.",
+  "error.invalidOptions": "yt-dlp rejected the download options. Your yt-dlp may be outdated — update it in Settings.",
+  "error.ytdlpNotFound": "yt-dlp was not found. Install it from Settings → Dependencies.",
+  "error.appClosedDuringDownload": "The app was closed while this download was running.",
+  "error.downloadPathUnavailable": "The download folder is unavailable (drive disconnected or folder can't be created). Check the download path in Settings and retry.",
+  "settings.cookieBrowserMissing": "{browser} (not detected)",
 }
 
 export default en

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -264,10 +264,10 @@ const fr: Record<string, string> = {
   "error.videoUnavailable": "Cette vidéo n'est pas disponible.",
   "error.unsupportedUrl": "Format d'URL non pris en charge.",
   "error.tooManyRequests": "Trop de requêtes. Veuillez réessayer dans un instant.",
-  "error.siteBlocked": "Le site a bloqué la requête (HTTP 410). La tentative d'usurpation du navigateur a aussi échoué. Réessayez plus tard, ou mettez à jour yt-dlp / configurez les cookies.",
+  "error.siteBlocked": "Le site a bloqué la requête (HTTP 410/403). La tentative d'usurpation du navigateur a aussi échoué. Réessayez plus tard, ou mettez à jour yt-dlp / configurez les cookies.",
   "error.noFormats": "Aucun format vidéo trouvé. Il peut s'agir d'un direct.",
   "error.ageRestricted": "Contenu soumis à une limite d'âge. Définissez un navigateur de cookies dans les Paramètres.",
-  "error.cookieAccess": "Impossible d'accéder aux cookies du navigateur. Fermez complètement le navigateur, ou utilisez les cookies de Firefox.",
+  "error.cookieAccess": "Impossible d'accéder aux cookies du navigateur. Fermez complètement le navigateur, ou changez/désactivez le navigateur de cookies dans les Paramètres.",
   "error.ytdlpGeneric": "Échec de la récupération des informations de la vidéo.",
   "error.ytdlpExecFailed": "Échec de l'exécution de yt-dlp.",
   "error.fetchTimeout": "La requête a expiré. Vérifiez votre connexion réseau.",
@@ -311,6 +311,15 @@ const fr: Record<string, string> = {
   // Added: history actions
   "history.revealInFolder": "Afficher dans le dossier",
   "history.deleteItem": "Supprimer",
+
+  // Added: error classification & i18n fixes
+  "error.botCheck": "YouTube a bloqué la requête comme trafic automatisé (vérification anti-bot). Définissez un navigateur de cookies dans les Paramètres pour y accéder connecté.",
+  "error.impersonateUnavailable": "Ce yt-dlp ne peut pas imiter un navigateur (curl_cffi manquant). Mettez à jour ou réinstallez yt-dlp dans les Paramètres, puis réessayez.",
+  "error.invalidOptions": "yt-dlp a rejeté les options de téléchargement. Votre yt-dlp est peut-être obsolète — mettez-le à jour dans les Paramètres.",
+  "error.ytdlpNotFound": "yt-dlp est introuvable. Installez-le depuis Paramètres → Dépendances.",
+  "error.appClosedDuringDownload": "L'application a été fermée pendant ce téléchargement.",
+  "error.downloadPathUnavailable": "Le dossier de téléchargement est indisponible (disque déconnecté ou dossier impossible à créer). Vérifiez le chemin de téléchargement dans les Paramètres, puis réessayez.",
+  "settings.cookieBrowserMissing": "{browser} (non détecté)",
 }
 
 export default fr

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -264,10 +264,10 @@ const ja: Record<string, string> = {
   "error.videoUnavailable": "この動画は利用できません。",
   "error.unsupportedUrl": "対応していないURL形式です。",
   "error.tooManyRequests": "リクエストが多すぎます。しばらくしてからもう一度お試しください。",
-  "error.siteBlocked": "サイトがアクセスをブロックしました（HTTP 410）。ブラウザ偽装での再試行も失敗しました。しばらくしてから再試行するか、yt-dlpの更新やCookie設定を確認してください。",
+  "error.siteBlocked": "サイトがアクセスをブロックしました（HTTP 410/403）。ブラウザ偽装での再試行も失敗しました。しばらくしてから再試行するか、yt-dlpの更新やCookie設定を確認してください。",
   "error.noFormats": "動画フォーマットが見つかりません。ライブ配信の可能性があります。",
   "error.ageRestricted": "年齢制限付きコンテンツです。設定でCookieブラウザを指定してください。",
-  "error.cookieAccess": "ブラウザのCookieにアクセスできません。ブラウザを完全に終了するか、FirefoxのCookieを使用してください。",
+  "error.cookieAccess": "ブラウザのCookieにアクセスできません。ブラウザを完全に終了するか、設定でCookieブラウザを変更・解除してください。",
   "error.ytdlpGeneric": "動画情報の取得に失敗しました。",
   "error.ytdlpExecFailed": "yt-dlpの実行に失敗しました。",
   "error.fetchTimeout": "リクエストがタイムアウトしました。ネットワーク接続を確認してください。",
@@ -311,6 +311,15 @@ const ja: Record<string, string> = {
   // Added: history actions
   "history.revealInFolder": "フォルダで表示",
   "history.deleteItem": "削除",
+
+  // Added: error classification & i18n fixes
+  "error.botCheck": "YouTubeが自動アクセス（ボット確認）としてブロックしました。設定でCookieブラウザを指定し、ログイン状態でアクセスしてください。",
+  "error.impersonateUnavailable": "現在のyt-dlpはブラウザ偽装に対応していません（curl_cffi未導入）。設定でyt-dlpを更新・再インストールしてから再試行してください。",
+  "error.invalidOptions": "yt-dlpがダウンロードオプションを認識できませんでした。yt-dlpが古い可能性があります。設定から更新してください。",
+  "error.ytdlpNotFound": "yt-dlpが見つかりません。設定 → 依存関係からインストールしてください。",
+  "error.appClosedDuringDownload": "ダウンロード中にアプリが終了しました。",
+  "error.downloadPathUnavailable": "ダウンロードフォルダーを使用できません（ドライブの切断またはフォルダー作成の失敗）。設定でダウンロード先を確認してから再試行してください。",
+  "settings.cookieBrowserMissing": "{browser}（未検出）",
 }
 
 export default ja

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -264,10 +264,10 @@ const ko: Record<string, string> = {
   "error.videoUnavailable": "이 영상은 사용할 수 없습니다.",
   "error.unsupportedUrl": "지원하지 않는 URL 형식입니다.",
   "error.tooManyRequests": "요청이 너무 많습니다. 잠시 후 다시 시도하세요.",
-  "error.siteBlocked": "사이트가 접근을 차단했습니다(HTTP 410). 브라우저 위장 재시도에도 실패했습니다. 잠시 후 다시 시도하거나 yt-dlp 업데이트/쿠키 설정을 확인하세요.",
+  "error.siteBlocked": "사이트가 접근을 차단했습니다(HTTP 410/403). 브라우저 위장 재시도에도 실패했습니다. 잠시 후 다시 시도하거나 yt-dlp 업데이트/쿠키 설정을 확인하세요.",
   "error.noFormats": "영상 형식을 찾을 수 없습니다. 라이브 스트림일 수 있습니다.",
   "error.ageRestricted": "연령 제한 콘텐츠입니다. 설정에서 쿠키 브라우저를 지정하세요.",
-  "error.cookieAccess": "브라우저 쿠키에 접근할 수 없습니다. 브라우저를 완전히 종료하거나 Firefox 쿠키를 사용하세요.",
+  "error.cookieAccess": "브라우저 쿠키에 접근할 수 없습니다. 브라우저를 완전히 종료하거나, 설정에서 쿠키 브라우저를 변경/해제하세요.",
   "error.ytdlpGeneric": "영상 정보를 가져오지 못했습니다.",
   "error.ytdlpExecFailed": "yt-dlp 실행에 실패했습니다.",
   "error.fetchTimeout": "요청 시간이 초과되었습니다. 네트워크 연결을 확인하세요.",
@@ -311,6 +311,15 @@ const ko: Record<string, string> = {
   // Added: history actions
   "history.revealInFolder": "폴더에서 보기",
   "history.deleteItem": "삭제",
+
+  // Added: error classification & i18n fixes
+  "error.botCheck": "YouTube가 자동화된 요청(봇 확인)으로 차단했습니다. 설정에서 쿠키 브라우저를 지정해 로그인 상태로 접근하세요.",
+  "error.impersonateUnavailable": "현재 yt-dlp가 브라우저 위장을 지원하지 않습니다(curl_cffi 없음). 설정에서 yt-dlp를 업데이트/재설치한 후 다시 시도하세요.",
+  "error.invalidOptions": "yt-dlp가 다운로드 옵션을 인식하지 못했습니다. yt-dlp가 오래된 버전일 수 있으니 설정에서 업데이트하세요.",
+  "error.ytdlpNotFound": "yt-dlp를 찾을 수 없습니다. 설정 → 의존성에서 설치하세요.",
+  "error.appClosedDuringDownload": "다운로드 진행 중에 앱이 종료되었습니다.",
+  "error.downloadPathUnavailable": "다운로드 폴더를 사용할 수 없습니다(드라이브 분리 또는 폴더 생성 실패). 설정에서 다운로드 경로를 확인한 후 다시 시도하세요.",
+  "settings.cookieBrowserMissing": "{browser} (감지되지 않음)",
 }
 
 export default ko

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -264,10 +264,10 @@ const zhCN: Record<string, string> = {
   "error.videoUnavailable": "该视频不可用。",
   "error.unsupportedUrl": "不支持的 URL 格式。",
   "error.tooManyRequests": "请求过多，请稍后再试。",
-  "error.siteBlocked": "网站拦截了请求（HTTP 410）。浏览器伪装重试也失败了。请稍后重试，或更新 yt-dlp／配置 Cookie。",
+  "error.siteBlocked": "网站拦截了请求（HTTP 410/403）。浏览器伪装重试也失败了。请稍后重试，或更新 yt-dlp／配置 Cookie。",
   "error.noFormats": "未找到视频格式，可能是直播。",
   "error.ageRestricted": "年龄限制内容。请在设置中指定 Cookie 浏览器。",
-  "error.cookieAccess": "无法访问浏览器 Cookie。请完全退出浏览器，或使用 Firefox Cookie。",
+  "error.cookieAccess": "无法访问浏览器 Cookie。请完全退出浏览器，或在设置中更改/清除 Cookie 浏览器。",
   "error.ytdlpGeneric": "获取视频信息失败。",
   "error.ytdlpExecFailed": "运行 yt-dlp 失败。",
   "error.fetchTimeout": "请求超时，请检查网络连接。",
@@ -311,6 +311,15 @@ const zhCN: Record<string, string> = {
   // Added: history actions
   "history.revealInFolder": "在文件夹中显示",
   "history.deleteItem": "删除",
+
+  // Added: error classification & i18n fixes
+  "error.botCheck": "YouTube 将该请求识别为自动化流量（人机验证）。请在设置中指定 Cookie 浏览器以登录状态访问。",
+  "error.impersonateUnavailable": "当前 yt-dlp 不支持浏览器伪装（缺少 curl_cffi）。请在设置中更新或重新安装 yt-dlp 后重试。",
+  "error.invalidOptions": "yt-dlp 无法识别下载选项。您的 yt-dlp 可能已过时，请在设置中更新。",
+  "error.ytdlpNotFound": "未找到 yt-dlp。请在 设置 → 依赖项 中安装。",
+  "error.appClosedDuringDownload": "下载进行时应用被关闭。",
+  "error.downloadPathUnavailable": "下载文件夹不可用（驱动器已断开或无法创建文件夹）。请在设置中检查下载路径后重试。",
+  "settings.cookieBrowserMissing": "{browser}（未检测到）",
 }
 
 export default zhCN

--- a/src/lib/i18n/locales/zh-TW.ts
+++ b/src/lib/i18n/locales/zh-TW.ts
@@ -264,10 +264,10 @@ const zhTW: Record<string, string> = {
   "error.videoUnavailable": "此影片無法使用。",
   "error.unsupportedUrl": "不支援的 URL 格式。",
   "error.tooManyRequests": "請求過多，請稍後再試。",
-  "error.siteBlocked": "網站封鎖了請求（HTTP 410）。瀏覽器偽裝重試也失敗了。請稍後重試，或更新 yt-dlp／設定 Cookie。",
+  "error.siteBlocked": "網站封鎖了請求（HTTP 410/403）。瀏覽器偽裝重試也失敗了。請稍後重試，或更新 yt-dlp／設定 Cookie。",
   "error.noFormats": "找不到影片格式，可能是直播。",
   "error.ageRestricted": "年齡限制內容。請在設定中指定 Cookie 瀏覽器。",
-  "error.cookieAccess": "無法存取瀏覽器 Cookie。請完全結束瀏覽器，或使用 Firefox Cookie。",
+  "error.cookieAccess": "無法存取瀏覽器 Cookie。請完全結束瀏覽器，或在設定中變更/清除 Cookie 瀏覽器。",
   "error.ytdlpGeneric": "取得影片資訊失敗。",
   "error.ytdlpExecFailed": "執行 yt-dlp 失敗。",
   "error.fetchTimeout": "請求逾時，請檢查網路連線。",
@@ -311,6 +311,15 @@ const zhTW: Record<string, string> = {
   // Added: history actions
   "history.revealInFolder": "在資料夾中顯示",
   "history.deleteItem": "刪除",
+
+  // Added: error classification & i18n fixes
+  "error.botCheck": "YouTube 將該請求視為自動化流量（人機驗證）。請在設定中指定 Cookie 瀏覽器以登入狀態存取。",
+  "error.impersonateUnavailable": "目前的 yt-dlp 不支援瀏覽器偽裝（缺少 curl_cffi）。請在設定中更新或重新安裝 yt-dlp 後再試。",
+  "error.invalidOptions": "yt-dlp 無法識別下載選項。您的 yt-dlp 可能已過時，請在設定中更新。",
+  "error.ytdlpNotFound": "找不到 yt-dlp。請在 設定 → 相依性 中安裝。",
+  "error.appClosedDuringDownload": "下載進行時應用程式被關閉。",
+  "error.downloadPathUnavailable": "下載資料夾無法使用（磁碟已中斷連線或無法建立資料夾）。請在設定中檢查下載路徑後再試。",
+  "settings.cookieBrowserMissing": "{browser}（未偵測到）",
 }
 
 export default zhTW

--- a/src/routes/tools/ytdlp/+page.svelte
+++ b/src/routes/tools/ytdlp/+page.svelte
@@ -27,7 +27,7 @@
   // cookie-browser picker for auth-related failures).
   let errorKey = $state<string | null>(null)
 
-  const COOKIE_ERROR_KEYS = ["error.ageRestricted", "error.cookieAccess", "error.siteBlocked"]
+  const COOKIE_ERROR_KEYS = ["error.ageRestricted", "error.cookieAccess", "error.siteBlocked", "error.botCheck"]
   const showCookieHint = $derived(errorKey != null && COOKIE_ERROR_KEYS.includes(errorKey))
 
   // Set the error banner from a backend AppError, remembering its key for contextual actions.
@@ -1133,6 +1133,11 @@
                   {#each browsers as browser}
                     <option value={browser}>{browser}</option>
                   {/each}
+                  {#if cookieBrowser && !browsers.includes(cookieBrowser)}
+                    <!-- Saved browser no longer detected (e.g. uninstalled): keep it visible
+                         with a warning instead of letting the select render blank. -->
+                    <option value={cookieBrowser}>{t("settings.cookieBrowserMissing", { browser: cookieBrowser })}</option>
+                  {/if}
                 </select>
              </div>
 


### PR DESCRIPTION
This PR makes failure reasons accurate, actionable, and localized: it fixes the bot-check/age-gate/cookie/exit-code-2 misclassifications in the yt-dlp error classifiers, stops storing raw English (and platform-wrong) strings in the queue database so every locale sees translated messages, and preflights the download directory so unplugged/offline drives fail fast with a clear, retryable error instead of a generic "Download failed".

## Fixes

- **YouTube bot-check and age-gate failures no longer misreported as "private video"** — `src-tauri/src/ytdlp/metadata/mod.rs`, `src/routes/tools/ytdlp/+page.svelte`: `map_stderr_error` now matches age-gate phrases and "not a bot" before the broad "Sign in" check (with a late bare-"Sign in" catch-all to `error.botCheck`), and `error.botCheck` was added to `COOKIE_ERROR_KEYS`, so users hit by YouTube's dominant anti-bot check finally see the correct reason and the one-click cookie fix instead of a dead-end "private video" message.
- **"Impersonate target is not available" and persistent 403s get correct, actionable errors** — `src-tauri/src/ytdlp/metadata/mod.rs`: a new `error.impersonateUnavailable` branch runs before the broad "not available" match (geo-block coverage preserved), and `HTTP Error 403`/`Forbidden` now map to `error.siteBlocked` (reworded to "HTTP 410/403" in all locales), so users no longer see "This video is unavailable." for videos that exist or a contentless generic error when persistently blocked.
- **Missing/unreadable cookie browser is now diagnosed instead of failing generically** — `src-tauri/src/ytdlp/metadata/mod.rs`, `src-tauri/src/ytdlp/download/executor.rs`, `src/routes/tools/ytdlp/+page.svelte`: both classifiers recognize the lowercase "cookies database" message as `error.cookieAccess` (reworded to suggest changing/clearing the cookie browser), and a saved-but-undetected browser now renders as a marked "(not detected)" option instead of a blank select, so users who uninstalled their cookie browser (or picked Safari without Full Disk Access) get a recovery path.
- **yt-dlp exit code 2 no longer misclassified as a network problem** — `src-tauri/src/ytdlp/download/executor.rs`: exit 2 (invalid options) maps to new `error.invalidOptions` pointing at an outdated yt-dlp, `extract_ytdlp_error` falls back to lowercase `yt-dlp: error:` optparse lines, and the `--impersonate` retry preserves attempt 1's exit code and stderr when the retry fails with "no such option", so users with an old system yt-dlp see the real 403 cause plus the outdated-binary detail instead of debugging their internet connection.
- **Lifecycle failure messages localized and sanitized in the queue DB** — `src-tauri/src/ytdlp/db/queue.rs`, `src-tauri/src/ytdlp/download/executor.rs`: `reset_stale_downloads` stores `error.appClosedDuringDownload`, the binary-resolution failure stores `error.ytdlpNotFound` in both the DB row and the emitted event (no more "install via Homebrew" on Windows), and `handle_download_failure` now takes a sanitized detail param so dynamic fatal causes (settings load, format selector, spawn failures) land in `error_detail` while `error_message` holds a stable i18n key — non-English users finally see translated failure reasons and no raw local paths.
- **fetch_video_info JSON paths return i18n keys instead of developer strings** — `src-tauri/src/ytdlp/metadata/fetch.rs`: JSON parse / missing-id / missing-title and `detect_url_type` parse failures map to `error.ytdlpGeneric`, missing formats to `error.noFormats`, with the sanitized raw detail logged via `logger::error_cat`, so users never see internals like "Failed to parse JSON: trailing characters at line 2 column 1" in the error banner.
- **Download directory preflight catches unplugged/offline drives** — `src-tauri/src/ytdlp/download/executor.rs`: `execute_download` walks the output template's path components to find the static prefix (stopping before the first component containing `%(`, mid-component placeholders covered and unit-tested) and runs `tokio::fs::create_dir_all` on it, routing failures through `handle_download_failure` with new `error.downloadPathUnavailable` — so a disconnected removable/network drive yields a clear, translatable, retryable error instead of cryptic per-item yt-dlp failures.

All 7 new i18n keys (`error.botCheck`, `error.impersonateUnavailable`, `error.invalidOptions`, `error.ytdlpNotFound`, `error.appClosedDuringDownload`, `error.downloadPathUnavailable`, `settings.cookieBrowserMissing`) were added to all 7 locale files (en, ko, ja, fr, de, zh-CN, zh-TW) with real translations; `error.siteBlocked` and `error.cookieAccess` were reworded in all 7. No specta surface changes — `src/lib/bindings.ts` is untouched.

## Verification

- `cargo fmt` — clean
- `cargo clippy -- -D warnings` — no warnings
- `cargo test` — 94 tests passed (including 9 new `map_stderr_error` ordering tests with real yt-dlp messages, the replaced `classify_invalid_options_on_code_2` test, and static-prefix extraction tests)
- `bun run check` (svelte-check) — no errors
- `bun run build` (vite build) — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
