### PR TITLE
fix: surface download/scan/update failures in the UI and stop silent state loss

### DIFF
--- a/src-tauri/src/ytdlp/download/commands.rs
+++ b/src-tauri/src/ytdlp/download/commands.rs
@@ -150,16 +150,38 @@ pub async fn add_to_queue_batch(
     security::sanitize_filename_template(&settings.filename_template)?;
 
     // Validate each request and build its output template (same as add_to_queue).
+    // Invalid entries are skipped (and logged) instead of `?`-failing the whole batch,
+    // so one bad URL can't poison the other items.
     let mut items = Vec::with_capacity(requests.len());
     for req in &requests {
-        security::sanitize_url(&req.video_url)?;
+        if let Err(e) = security::sanitize_url(&req.video_url) {
+            logger::warn_cat(
+                "download",
+                &format!("Skipping invalid batch entry '{}': {}", req.video_url, e),
+            );
+            continue;
+        }
         let output_dir = req.output_dir.as_deref().unwrap_or(&settings.download_path);
-        security::sanitize_output_path(output_dir)?;
+        if let Err(e) = security::sanitize_output_path(output_dir) {
+            logger::warn_cat(
+                "download",
+                &format!(
+                    "Skipping batch entry '{}': invalid output path: {}",
+                    req.video_url, e
+                ),
+            );
+            continue;
+        }
         let output_template = std::path::Path::new(output_dir)
             .join(&settings.filename_template)
             .to_string_lossy()
             .to_string();
         items.push((req.clone(), output_template));
+    }
+
+    // Never create an empty group: if every entry was invalid, fail loudly instead.
+    if items.is_empty() {
+        return Err(AppError::InvalidUrl("No valid URLs in batch".to_string()));
     }
 
     let db_state = app.state::<crate::DbState>();

--- a/src-tauri/src/ytdlp/metadata/fetch.rs
+++ b/src-tauri/src/ytdlp/metadata/fetch.rs
@@ -208,8 +208,19 @@ pub(super) fn parse_flat_entry(entry: &serde_json::Value) -> Option<PlaylistEntr
             Some(id) if is_youtube || ie_key.is_empty() => {
                 format!("https://www.youtube.com/watch?v={}", id)
             }
-            // 비-YouTube + id-form이면 그대로 둬 yt-dlp가 ie_key로 재해석하게 한다.
-            Some(id) => id.to_string(),
+            // 비-YouTube + id-form은 다운로드 경로의 sanitize_url이 어차피 거부한다
+            // (ie_key 컨텍스트가 yt-dlp까지 전달되지 않으므로 bare id는 다운로드 불가).
+            // 배치 전체를 오염시키지 말고 항목을 건너뛴다.
+            Some(id) => {
+                logger::warn_cat(
+                    "metadata",
+                    &format!(
+                        "Skipping id-only flat entry without a usable URL ({}: {})",
+                        ie_key, id
+                    ),
+                );
+                return None;
+            }
             None => String::new(),
         },
     };
@@ -457,10 +468,11 @@ mod tests {
     }
 
     #[test]
-    fn flat_entry_keeps_non_youtube_ids_verbatim() {
+    fn flat_entry_skips_id_only_non_youtube_entries() {
+        // A bare non-YouTube id can never be downloaded (sanitize_url rejects non-http
+        // values), so the entry must be dropped instead of poisoning a batch enqueue.
         let entry = serde_json::json!({ "id": "BV1xx411c7mD", "ie_key": "BiliBili" });
-        let parsed = parse_flat_entry(&entry).unwrap();
-        assert_eq!(parsed.url, "BV1xx411c7mD");
+        assert!(parse_flat_entry(&entry).is_none());
     }
 
     #[test]

--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -322,6 +322,15 @@ const de: Record<string, string> = {
   "error.appClosedDuringDownload": "Die App wurde geschlossen, während dieser Download lief.",
   "error.downloadPathUnavailable": "Der Download-Ordner ist nicht verfügbar (Laufwerk getrennt oder Ordner kann nicht erstellt werden). Prüfen Sie den Download-Pfad in den Einstellungen und versuchen Sie es erneut.",
   "settings.cookieBrowserMissing": "{browser} (nicht erkannt)",
+
+  // Added: failure visibility (download toast, queue badge, queue actions, updater)
+  "layout.downloadFailedToast": "Download fehlgeschlagen: {title}",
+  "layout.failedCount": "{count} Download(s) fehlgeschlagen",
+  "queue.actionFailed": "Aktion fehlgeschlagen",
+  "update.failed": "Update fehlgeschlagen",
+  "update.restartNow": "Jetzt neu starten",
+  "update.restartManually": "Das Update wurde installiert, aber der automatische Neustart ist fehlgeschlagen. Bitte starte die App manuell neu.",
+  "update.hide": "Ausblenden",
 }
 
 export default de

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -330,6 +330,15 @@ const en: Record<string, string> = {
   "error.appClosedDuringDownload": "The app was closed while this download was running.",
   "error.downloadPathUnavailable": "The download folder is unavailable (drive disconnected or folder can't be created). Check the download path in Settings and retry.",
   "settings.cookieBrowserMissing": "{browser} (not detected)",
+
+  // Added: failure visibility (download toast, queue badge, queue actions, updater)
+  "layout.downloadFailedToast": "Download failed: {title}",
+  "layout.failedCount": "{count} download(s) failed",
+  "queue.actionFailed": "Action failed",
+  "update.failed": "Update failed",
+  "update.restartNow": "Restart now",
+  "update.restartManually": "The update was installed, but the app couldn't restart automatically. Please restart it manually.",
+  "update.hide": "Hide",
 }
 
 export default en

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -322,6 +322,15 @@ const fr: Record<string, string> = {
   "error.appClosedDuringDownload": "L'application a été fermée pendant ce téléchargement.",
   "error.downloadPathUnavailable": "Le dossier de téléchargement est indisponible (disque déconnecté ou dossier impossible à créer). Vérifiez le chemin de téléchargement dans les Paramètres, puis réessayez.",
   "settings.cookieBrowserMissing": "{browser} (non détecté)",
+
+  // Added: failure visibility (download toast, queue badge, queue actions, updater)
+  "layout.downloadFailedToast": "Échec du téléchargement : {title}",
+  "layout.failedCount": "{count} téléchargement(s) échoué(s)",
+  "queue.actionFailed": "L'action a échoué",
+  "update.failed": "Échec de la mise à jour",
+  "update.restartNow": "Redémarrer maintenant",
+  "update.restartManually": "La mise à jour a été installée, mais le redémarrage automatique a échoué. Veuillez redémarrer l'application manuellement.",
+  "update.hide": "Masquer",
 }
 
 export default fr

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -322,6 +322,15 @@ const ja: Record<string, string> = {
   "error.appClosedDuringDownload": "ダウンロード中にアプリが終了しました。",
   "error.downloadPathUnavailable": "ダウンロードフォルダーを使用できません（ドライブの切断またはフォルダー作成の失敗）。設定でダウンロード先を確認してから再試行してください。",
   "settings.cookieBrowserMissing": "{browser}（未検出）",
+
+  // Added: failure visibility (download toast, queue badge, queue actions, updater)
+  "layout.downloadFailedToast": "ダウンロード失敗: {title}",
+  "layout.failedCount": "{count}件のダウンロードが失敗しました",
+  "queue.actionFailed": "操作を実行できませんでした",
+  "update.failed": "アップデートに失敗しました",
+  "update.restartNow": "今すぐ再起動",
+  "update.restartManually": "アップデートはインストールされましたが、自動再起動に失敗しました。手動でアプリを再起動してください。",
+  "update.hide": "非表示",
 }
 
 export default ja

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -322,6 +322,15 @@ const ko: Record<string, string> = {
   "error.appClosedDuringDownload": "다운로드 진행 중에 앱이 종료되었습니다.",
   "error.downloadPathUnavailable": "다운로드 폴더를 사용할 수 없습니다(드라이브 분리 또는 폴더 생성 실패). 설정에서 다운로드 경로를 확인한 후 다시 시도하세요.",
   "settings.cookieBrowserMissing": "{browser} (감지되지 않음)",
+
+  // Added: failure visibility (download toast, queue badge, queue actions, updater)
+  "layout.downloadFailedToast": "다운로드 실패: {title}",
+  "layout.failedCount": "{count}개 다운로드 실패",
+  "queue.actionFailed": "작업을 처리하지 못했습니다",
+  "update.failed": "업데이트 실패",
+  "update.restartNow": "지금 재시작",
+  "update.restartManually": "업데이트는 설치되었지만 자동 재시작에 실패했습니다. 앱을 직접 재시작해 주세요.",
+  "update.hide": "숨기기",
 }
 
 export default ko

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -322,6 +322,15 @@ const zhCN: Record<string, string> = {
   "error.appClosedDuringDownload": "下载进行时应用被关闭。",
   "error.downloadPathUnavailable": "下载文件夹不可用（驱动器已断开或无法创建文件夹）。请在设置中检查下载路径后重试。",
   "settings.cookieBrowserMissing": "{browser}（未检测到）",
+
+  // Added: failure visibility (download toast, queue badge, queue actions, updater)
+  "layout.downloadFailedToast": "下载失败：{title}",
+  "layout.failedCount": "{count} 个下载失败",
+  "queue.actionFailed": "操作失败",
+  "update.failed": "更新失败",
+  "update.restartNow": "立即重启",
+  "update.restartManually": "更新已安装，但自动重启失败。请手动重启应用。",
+  "update.hide": "隐藏",
 }
 
 export default zhCN

--- a/src/lib/i18n/locales/zh-TW.ts
+++ b/src/lib/i18n/locales/zh-TW.ts
@@ -322,6 +322,15 @@ const zhTW: Record<string, string> = {
   "error.appClosedDuringDownload": "下載進行時應用程式被關閉。",
   "error.downloadPathUnavailable": "下載資料夾無法使用（磁碟已中斷連線或無法建立資料夾）。請在設定中檢查下載路徑後再試。",
   "settings.cookieBrowserMissing": "{browser}（未偵測到）",
+
+  // Added: failure visibility (download toast, queue badge, queue actions, updater)
+  "layout.downloadFailedToast": "下載失敗：{title}",
+  "layout.failedCount": "{count} 個下載失敗",
+  "queue.actionFailed": "操作失敗",
+  "update.failed": "更新失敗",
+  "update.restartNow": "立即重新啟動",
+  "update.restartManually": "更新已安裝，但自動重新啟動失敗。請手動重新啟動應用程式。",
+  "update.hide": "隱藏",
 }
 
 export default zhTW

--- a/src/routes/tools/ytdlp/+layout.svelte
+++ b/src/routes/tools/ytdlp/+layout.svelte
@@ -52,6 +52,9 @@
   let progressCache = $state<Map<number, ProgressCacheEntry>>(new Map())
   let activeCount = $derived(activeDownloads.filter(d => d.status === "downloading").length)
   let pendingCount = $derived(activeDownloads.filter(d => d.status === "pending").length)
+  // Failed rows never appear in the queue summary (it only carries downloading/pending +
+  // recent completed), so count them separately from the full queue.
+  let failedCount = $state(0)
 
   // Toast state
   let toastMessage = $state("")
@@ -69,6 +72,7 @@
   let updateTotalSize = $state(0)
   let updateDownloaded = $state(0)
   let updateReady = $state(false)
+  let updateError = $state<string | null>(null)
 
   // Welcome (first-run) state
   type DepMode = "hybrid" | "bundled"
@@ -159,7 +163,13 @@
 
   async function loadQueueSummary() {
     try {
-      const result = await commands.getQueueSummary()
+      const [result, queueResult] = await Promise.all([
+        commands.getQueueSummary(),
+        commands.getActiveQueue(),
+      ])
+      if (queueResult.status === "ok") {
+        failedCount = queueResult.data.filter((d) => d.status === "failed").length
+      }
       if (result.status === "ok") {
         const data = result.data
         activeDownloads = data.activeItems.map((item: any) => {
@@ -192,8 +202,14 @@
       const result = await commands.cancelAllDownloads()
       if (result.status === "ok") {
         await queueSummaryPromise
+      } else {
+        console.error("Failed to cancel all downloads:", result.error)
+        showErrorToast(extractError(result.error))
       }
-    } catch (e) { console.error("Failed to cancel all downloads:", e) }
+    } catch (e: any) {
+      console.error("Failed to cancel all downloads:", e)
+      showErrorToast(e?.message || String(e))
+    }
     // Refresh immediately
     loadQueueSummary()
   }
@@ -330,6 +346,11 @@
           if (data.eventType === "completed") {
             const title = activeDownloads.find(d => d.id === data.taskId)?.title
             showToast(t("layout.downloadComplete", { title: title || "video" }), "download_done")
+          } else if (data.eventType === "error") {
+            // Look up the title before the summary refresh drops the failed row from
+            // activeDownloads. "cancelled" stays silent — it's user-initiated.
+            const title = activeDownloads.find(d => d.id === data.taskId)?.title
+            showErrorToast(`${t("layout.downloadFailedToast", { title: title || "video" })} — ${t(data.message ?? "error.downloadFailed")}`)
           }
           debouncedLoadQueueSummary()
         }
@@ -382,8 +403,10 @@
   function handleDebugKey(e: KeyboardEvent) {
     if (e.key === "Escape") {
       // Dismiss the lightest-weight open dialog first. The blocked-close dialog stays put on
-      // Escape (closing it would imply a choice), so it's intentionally excluded here.
-      if (showUpdateDialog && !updateDownloading) { showUpdateDialog = false; return }
+      // Escape (closing it would imply a choice), so it's intentionally excluded here. The
+      // update dialog may be hidden even mid-download — the download keeps running in the
+      // background and the dialog re-surfaces when it finishes or fails.
+      if (showUpdateDialog) { showUpdateDialog = false; return }
       if (showCloseDialog) { showCloseDialog = false; rememberChoice = false; return }
     }
     if (e.key === "F10") {
@@ -562,6 +585,8 @@
     updateDownloaded = 0
     updateTotalSize = 0
     updateProgress = 0
+    updateReady = false
+    updateError = null
     try {
       await updateInfo.downloadAndInstall((progress) => {
         if (progress.event === "Started" && progress.data.contentLength) {
@@ -575,10 +600,28 @@
           updateReady = true
         }
       })
-      await relaunch()
+      updateReady = true
+      updateProgress = 100
     } catch (e) {
       console.error("Update failed:", e)
+      updateError = e instanceof Error ? e.message : String(e)
+      updateReady = false
+      updateProgress = 0
+      updateDownloaded = 0
+    } finally {
       updateDownloading = false
+      // The dialog may have been hidden during the download; never restart (or fail)
+      // silently in the background — re-surface it and let the user choose.
+      showUpdateDialog = true
+    }
+  }
+
+  async function handleRestartNow() {
+    try {
+      await relaunch()
+    } catch (e) {
+      console.error("Relaunch failed:", e)
+      updateError = t("update.restartManually")
     }
   }
 
@@ -667,8 +710,8 @@
         >
           <span class="material-symbols-outlined text-[20px] {isActive(item.href, item.exact) ? 'text-yt-primary' : ''}">{item.icon}</span>
           <span>{t(item.labelKey)}</span>
-          {#if item.href === "/tools/ytdlp/queue" && (activeCount + pendingCount) > 0}
-            <span class="absolute right-2 w-2 h-2 bg-yt-primary rounded-full ring-2 ring-yt-surface animate-pulse"></span>
+          {#if item.href === "/tools/ytdlp/queue" && (activeCount + pendingCount + failedCount) > 0}
+            <span class="absolute right-2 w-2 h-2 {(activeCount + pendingCount) > 0 ? 'bg-yt-primary' : 'bg-yt-error'} rounded-full ring-2 ring-yt-surface animate-pulse"></span>
           {/if}
         </a>
       {/each}
@@ -688,7 +731,7 @@
     <!-- Update Button -->
     <div class="px-3 mb-1">
       <button
-        onclick={() => { showUpdateDialog = true }}
+        onclick={() => { updateError = null; showUpdateDialog = true }}
         class="flex items-center gap-3 px-3 py-2 rounded-md transition-colors text-sm font-medium text-yt-text-secondary hover:bg-yt-overlay hover:text-yt-text w-full"
       >
         <span class="material-symbols-outlined text-[20px]">system_update</span>
@@ -708,8 +751,8 @@
         <div class="flex items-center gap-2.5">
           <div class="relative">
              <span class="material-symbols-outlined text-yt-text-secondary group-hover:text-yt-text text-[20px]">downloading</span>
-             {#if (activeCount + pendingCount) > 0}
-              <span class="absolute -top-1 -right-1 w-2.5 h-2.5 bg-yt-primary rounded-full ring-2 ring-yt-surface"></span>
+             {#if (activeCount + pendingCount + failedCount) > 0}
+              <span class="absolute -top-1 -right-1 w-2.5 h-2.5 {(activeCount + pendingCount) > 0 ? 'bg-yt-primary' : 'bg-yt-error'} rounded-full ring-2 ring-yt-surface"></span>
              {/if}
           </div>
           <div class="text-left">
@@ -1011,10 +1054,22 @@
       </div>
 
       <div class="flex-1 overflow-y-auto hide-scrollbar p-2 space-y-2">
-        {#if activeDownloads.length === 0 && recentCompleted.length === 0}
+        {#if activeDownloads.length === 0 && recentCompleted.length === 0 && failedCount === 0}
            <div class="py-8 text-center">
              <p class="text-xs text-yt-text-muted">{t("layout.noActiveDownloads")}</p>
            </div>
+        {/if}
+
+        {#if failedCount > 0}
+          <a
+            href="/tools/ytdlp/queue"
+            onclick={() => popupOpen = false}
+            class="flex items-center gap-2 px-2.5 py-2 rounded bg-yt-error/10 border border-yt-error/20 hover:bg-yt-error/15 transition-colors"
+          >
+            <span class="material-symbols-outlined text-yt-error text-[16px]">error</span>
+            <span class="text-xs text-yt-error font-medium flex-1">{t("layout.failedCount", { count: failedCount })}</span>
+            <span class="material-symbols-outlined text-yt-error/70 text-[14px]">chevron_right</span>
+          </a>
         {/if}
 
         {#each activeDownloads as item (item.id)}
@@ -1105,7 +1160,7 @@
             </div>
           {/if}
 
-          {#if updateDownloading}
+          {#if updateDownloading || updateReady}
             <div class="mb-4">
               <div class="flex items-center justify-between mb-2">
                 <p class="text-xs text-yt-text-secondary">
@@ -1122,8 +1177,48 @@
             </div>
           {/if}
 
+          {#if updateError}
+            <div class="mb-4 bg-yt-error/10 border border-yt-error/20 rounded-lg px-3 py-2 flex items-start gap-2">
+              <span class="material-symbols-outlined text-yt-error text-[18px] shrink-0 mt-0.5">error</span>
+              <div class="min-w-0">
+                <p class="text-xs text-yt-text font-medium">{t("update.failed")}</p>
+                <p class="text-xs text-yt-text-secondary mt-0.5 break-all">{updateError}</p>
+              </div>
+            </div>
+          {/if}
+
           <div class="flex gap-3">
-            {#if !updateDownloading}
+            {#if updateDownloading}
+              <!-- The download can't be aborted, but the dialog can be hidden; it re-surfaces
+                   once downloadAndInstall settles, so the app is never locked behind it. -->
+              <button
+                onclick={() => { showUpdateDialog = false }}
+                class="flex-1 px-4 py-2 rounded-lg bg-yt-highlight hover:bg-yt-border text-yt-text text-sm font-medium transition-colors"
+              >
+                {t("update.hide")}
+              </button>
+              <button
+                disabled
+                class="flex-1 px-4 py-2 rounded-lg bg-yt-highlight text-yt-text-secondary text-sm font-medium cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                <span class="material-symbols-outlined text-[18px] animate-spin">progress_activity</span>
+                {t("update.downloading")}
+              </button>
+            {:else if updateReady}
+              <button
+                onclick={() => { showUpdateDialog = false }}
+                class="flex-1 px-4 py-2 rounded-lg bg-yt-highlight hover:bg-yt-border text-yt-text text-sm font-medium transition-colors"
+              >
+                {t("update.later")}
+              </button>
+              <button
+                onclick={handleRestartNow}
+                class="flex-1 px-4 py-2 rounded-lg bg-yt-primary hover:bg-yt-primary-hover text-white text-sm font-medium transition-colors flex items-center justify-center gap-2"
+              >
+                <span class="material-symbols-outlined text-[18px]">restart_alt</span>
+                {t("update.restartNow")}
+              </button>
+            {:else}
               <button
                 onclick={() => { showUpdateDialog = false }}
                 class="flex-1 px-4 py-2 rounded-lg bg-yt-highlight hover:bg-yt-border text-yt-text text-sm font-medium transition-colors"
@@ -1136,14 +1231,6 @@
               >
                 <span class="material-symbols-outlined text-[18px]">download</span>
                 {t("update.install")}
-              </button>
-            {:else}
-              <button
-                disabled
-                class="flex-1 px-4 py-2 rounded-lg bg-yt-highlight text-yt-text-secondary text-sm font-medium cursor-not-allowed flex items-center justify-center gap-2"
-              >
-                <span class="material-symbols-outlined text-[18px] animate-spin">progress_activity</span>
-                {t("update.downloading")}
               </button>
             {/if}
           </div>

--- a/src/routes/tools/ytdlp/+page.svelte
+++ b/src/routes/tools/ytdlp/+page.svelte
@@ -1,3 +1,11 @@
+<script module lang="ts">
+  // Scan ids must stay unique across page remounts and webview reloads: a delayed terminal
+  // event from a killed scan must never match a new scan's id (the backend's scan_id is a
+  // u32, so never seed from Date.now()). Module scope survives remounts; the random seed
+  // covers full reloads (F5/HMR) while backend scan tasks linger.
+  let scanSeq = Math.floor(Math.random() * 0x7fffffff)
+</script>
+
 <script lang="ts">
   import { commands, type PlaylistScanMeta, type PlaylistScanEvent, type PlaylistEntry, type DuplicateCheckResult, type QuickMetadata, type AdvancedOptions } from "$lib/bindings"
   import {
@@ -11,7 +19,7 @@
   } from "$lib/advanced"
   import { platform } from "@tauri-apps/plugin-os"
   import { listen } from "@tauri-apps/api/event"
-  import { onMount, onDestroy } from "svelte"
+  import { onMount, onDestroy, untrack } from "svelte"
   import { t } from "$lib/i18n/index.svelte"
   import { extractError, getErrorKey } from "$lib/utils/errors"
   import { formatSize, formatDuration } from "$lib/utils/format"
@@ -51,7 +59,9 @@
   // the handler's id check even when it arrives before the invoke ack.
   let scanning = $state(false)
   let scanId = $state<number | null>(null)
-  let scanSeq = 0
+  // Trimmed URL (as typed) that started the active scan — used to ignore same-URL
+  // re-analyze requests while the scan is still streaming.
+  let activeScanUrl: string | null = null
   // De-dup across batches (yt-dlp continuations can occasionally repeat entries).
   let seenVideoIds = new Set<string>()
   // Resolved when the scan reaches a terminal state (done/error/cancelled) — Download All waits on it.
@@ -217,11 +227,15 @@
     const currentUrl = url // Only tracked dependency
     clearAnalyzeDebounce()
     // A duplicate warning belongs to a specific URL; once the user edits the field it no longer
-    // matches what's on screen, so drop it (and its captured request) right away.
-    if (duplicateCheck && currentUrl.trim() !== duplicateUrl) {
-      duplicateCheck = null
-      pendingRequest = null
-    }
+    // matches what's on screen, so drop it (and its captured request) right away. untrack keeps
+    // duplicateCheck/duplicateUrl out of the dependency set, so raising or dismissing the
+    // warning can't re-run this effect and schedule a re-analysis that wipes the dialog.
+    untrack(() => {
+      if (duplicateCheck && currentUrl.trim() !== duplicateUrl) {
+        duplicateCheck = null
+        pendingRequest = null
+      }
+    })
     if (looksLikeVideoUrl(currentUrl)) {
       analyzeTimeoutId = setTimeout(() => {
         // Don't gate on `analyzing`: if a previous fetch is still in flight, handleAnalyze bumps
@@ -431,6 +445,7 @@
       commands.cancelPlaylistScan(scanId).catch(() => {})
       scanId = null
     }
+    activeScanUrl = null
     scanning = false
     scanFinished = null
     settleScanWaiters()
@@ -489,6 +504,10 @@
   async function handleAnalyze() {
     const requestedUrl = url.trim()
     if (!requestedUrl) return
+    // A reflexive Enter (or whitespace-only edit) while a scan of the same URL is still
+    // streaming must not silently restart it from entry zero; cancel via the in-field X
+    // first to rescan the same URL.
+    if (scanning && requestedUrl === activeScanUrl) return
     if (analyzePromise && analyzePromiseUrl === requestedUrl) {
       await analyzePromise
       return
@@ -592,6 +611,7 @@
         const id = ++scanSeq
         // Set BEFORE invoking: the first "entries" event can arrive before the invoke resolves.
         scanId = id
+        activeScanUrl = requestedUrl
         scanning = true
         scanFinished = new Promise((resolve) => { resolveScanFinished = resolve })
         const firstResult = new Promise<void>((resolve) => { resolveFirstScanResult = resolve })
@@ -796,7 +816,10 @@
     }
   }
 
-  async function enqueueBatchDownloads(entries: Array<{ url: string, videoId: string, title: string | null }>) {
+  // Returns true when the batch is enqueued (or every entry was skipped as a duplicate),
+  // false when the backend rejected it — callers must keep the page state for a retry then.
+  async function enqueueBatchDownloads(entries: Array<{ url: string, videoId: string, title: string | null }>): Promise<boolean> {
+    const generation = analyzeGeneration
     const totalCount = entries.length
     batchProgress = { current: 0, total: totalCount }
     const formatStr = buildFormatString()
@@ -830,7 +853,7 @@
     if (skippedExistsTitles.length > 0) messages.push(t("download.skippedExists", { count: skippedExistsTitles.length }))
     if (messages.length) notice = messages.join(" ")
 
-    if (survivors.length === 0) return
+    if (survivors.length === 0) return true
 
     const requests = survivors.map((entry) => ({
       videoUrl: entry.url,
@@ -851,9 +874,14 @@
 
     if (result.status === "error") {
       console.error("Batch enqueue failed:", extractError(result.error))
-    } else {
-      window.dispatchEvent(new CustomEvent("queue-added", { detail: { count: survivors.length } }))
+      batchProgress = { current: 0, total: 0 }
+      // Don't surface a stale failure over a newer analysis.
+      if (generation === analyzeGeneration) setError(result.error)
+      return false
     }
+    // The backend may skip invalid entries, so report the actually-enqueued count.
+    window.dispatchEvent(new CustomEvent("queue-added", { detail: { count: result.data.taskIds.length } }))
+    return true
   }
 
   async function handleDownloadSelected() {
@@ -865,12 +893,14 @@
 
     try {
       const entries = playlistResult.entries.filter(e => selectedEntries.has(e.videoId))
-      await enqueueBatchDownloads(entries)
-      url = ""
-      videoInfo = null
-      playlistResult = null
-      cancelActiveScan()
-      selectedEntries = new Set()
+      // On failure keep the list, the selection, and the live scan so the user can retry.
+      if (await enqueueBatchDownloads(entries)) {
+        url = ""
+        videoInfo = null
+        playlistResult = null
+        cancelActiveScan()
+        selectedEntries = new Set()
+      }
     } catch (e: any) {
       errorKey = null
       error = e.message || String(e)
@@ -896,8 +926,12 @@
         return
       }
 
-      await enqueueBatchDownloads(playlistResult.entries)
+      const enqueued = await enqueueBatchDownloads(playlistResult.entries)
       if (downloadGeneration !== analyzeGeneration) {
+        return
+      }
+      // On failure keep the scanned list on screen so the user can retry without rescanning.
+      if (!enqueued) {
         return
       }
 
@@ -1028,7 +1062,7 @@
             onkeydown={handleKeydown}
             disabled={downloading}
           />
-           {#if analyzing}
+           {#if analyzing || scanning}
             <div class="absolute inset-y-0 right-3 flex items-center gap-2">
                <span class="material-symbols-outlined text-yt-primary text-[18px] animate-spin">progress_activity</span>
                {#if analyzeElapsed > 0}<span class="text-xs text-yt-text-secondary font-mono">{analyzeElapsed}s</span>{/if}

--- a/src/routes/tools/ytdlp/queue/+page.svelte
+++ b/src/routes/tools/ytdlp/queue/+page.svelte
@@ -6,6 +6,7 @@
   import { revealItemInDir } from "@tauri-apps/plugin-opener"
   import { onMount, onDestroy } from "svelte"
   import { t, getDateLocale } from "$lib/i18n/index.svelte"
+  import { extractError } from "$lib/utils/errors"
   import { formatSize } from "$lib/utils/format"
   import { fade } from "svelte/transition"
   import GroupHeader from "$lib/components/GroupHeader.svelte"
@@ -23,6 +24,8 @@
   let searchTimeout: ReturnType<typeof setTimeout>
   let activeFilter = $state<string | null>(null)
   let busyActions = $state<Set<string>>(new Set())
+  // Last queue/history action failure (retry/cancel/clear/delete), shown as a dismissible banner.
+  let actionError = $state<string | null>(null)
 
   // Batch-group fold-out state. Active groups default expanded (you're watching them
   // download); history groups default collapsed. Both survive the 2s poll since they
@@ -140,6 +143,7 @@
 
   async function withBusy(key: string, action: () => Promise<void>) {
     if (busyActions.has(key)) return
+    actionError = null
     busyActions = new Set([...busyActions, key])
     try {
       await action()
@@ -233,7 +237,14 @@
       try {
         const r = await commands.cancelDownload(id)
         if (r.status === "ok") await loadActive()
-      } catch (e) { console.error("Failed to cancel:", e) }
+        else {
+          console.error("Failed to cancel:", r.error)
+          actionError = extractError(r.error)
+        }
+      } catch (e: any) {
+        console.error("Failed to cancel:", e)
+        actionError = e?.message || String(e)
+      }
     })
   }
 
@@ -242,7 +253,14 @@
       try {
         const r = await commands.retryDownload(id)
         if (r.status === "ok") await loadActive()
-      } catch (e) { console.error("Failed to retry:", e) }
+        else {
+          console.error("Failed to retry:", r.error)
+          actionError = extractError(r.error)
+        }
+      } catch (e: any) {
+        console.error("Failed to retry:", e)
+        actionError = e?.message || String(e)
+      }
     })
   }
 
@@ -251,7 +269,14 @@
       try {
         const r = await commands.cancelAllDownloads()
         if (r.status === "ok") await loadActive()
-      } catch (e) { console.error("Failed to cancel all:", e) }
+        else {
+          console.error("Failed to cancel all:", r.error)
+          actionError = extractError(r.error)
+        }
+      } catch (e: any) {
+        console.error("Failed to cancel all:", e)
+        actionError = e?.message || String(e)
+      }
     })
   }
 
@@ -260,7 +285,14 @@
       try {
         const r = await commands.cancelGroup(gid)
         if (r.status === "ok") await loadActive()
-      } catch (e) { console.error("Failed to cancel group:", e) }
+        else {
+          console.error("Failed to cancel group:", r.error)
+          actionError = extractError(r.error)
+        }
+      } catch (e: any) {
+        console.error("Failed to cancel group:", e)
+        actionError = e?.message || String(e)
+      }
     })
   }
 
@@ -272,8 +304,14 @@
         if (r.status === "ok") {
           activeFilter = null
           await Promise.all([loadActive(), loadHistory()])
+        } else {
+          console.error("Failed to clear all:", r.error)
+          actionError = extractError(r.error)
         }
-      } catch (e) { console.error("Failed to clear all:", e) }
+      } catch (e: any) {
+        console.error("Failed to clear all:", e)
+        actionError = e?.message || String(e)
+      }
     })
   }
 
@@ -283,7 +321,14 @@
       try {
         const r = await commands.deleteHistoryItem(id)
         if (r.status === "ok") await loadHistory()
-      } catch (e) { console.error("Failed to delete history item:", e) }
+        else {
+          console.error("Failed to delete history item:", r.error)
+          actionError = extractError(r.error)
+        }
+      } catch (e: any) {
+        console.error("Failed to delete history item:", e)
+        actionError = e?.message || String(e)
+      }
     })
   }
 
@@ -293,7 +338,14 @@
       try {
         const r = await commands.deleteHistoryGroup(gid)
         if (r.status === "ok") await loadHistory()
-      } catch (e) { console.error("Failed to delete history group:", e) }
+        else {
+          console.error("Failed to delete history group:", r.error)
+          actionError = extractError(r.error)
+        }
+      } catch (e: any) {
+        console.error("Failed to delete history group:", e)
+        actionError = e?.message || String(e)
+      }
     })
   }
 
@@ -470,6 +522,19 @@
       </div>
     </div>
   </header>
+
+  {#if actionError}
+    <div class="mx-6 mt-4 bg-yt-error/10 border border-yt-error/20 rounded-lg px-4 py-3 flex items-start gap-3">
+      <span class="material-symbols-outlined text-yt-error text-[20px] shrink-0 mt-0.5">error</span>
+      <div class="flex-1 min-w-0">
+        <p class="text-sm text-yt-text font-medium">{t("queue.actionFailed")}</p>
+        <p class="text-xs text-yt-text-secondary mt-0.5">{actionError}</p>
+      </div>
+      <button class="text-yt-text-secondary hover:text-yt-text" aria-label={t("download.close")} onclick={() => actionError = null}>
+        <span class="material-symbols-outlined text-[18px]">close</span>
+      </button>
+    </div>
+  {/if}
 
   {#if firstLoad}
     <div class="flex justify-center py-16">


### PR DESCRIPTION
This PR eliminates a class of frontend silent failures: every failed operation (batch enqueue, download, queue action, app update) now shows visible feedback, and the duplicate-download/scan flows no longer destroy user state. Previously, errors were swallowed into `console.error`, UI state was cleared as if operations had succeeded, and the duplicate-download warning self-destructed before it could be used — leaving users with no way to know an operation failed or to retry it.

## Fixes

- **frontend-stability#0 — Duplicate-download warning self-destructs** (`src/routes/tools/ytdlp/+page.svelte`): the auto-analyze `$effect` now reads `duplicateCheck`/`duplicateUrl` inside `untrack()`, so the "already downloaded" warning no longer vanishes after ~800ms and "Download anyway" is usable again — re-downloading a video from history works.
- **error-reporting#2 — Batch enqueue failure swallowed** (`src/routes/tools/ytdlp/+page.svelte`): `enqueueBatchDownloads` now returns a success flag and surfaces backend errors via the existing `setError` pipeline (generation-guarded so a stale failure can't error a newer analysis), instead of logging to console only.
- **metadata-scan#0 — Playlist state cleared as if enqueue succeeded** (`src/routes/tools/ytdlp/+page.svelte`): `handleDownloadSelected`/`handleDownloadAll` only clear the URL, video info, playlist result, and selection on success, so a scanned playlist stays on screen for retry after a failed enqueue.
- **frontend-stability#1 — Silent loss of scan results on enqueue error** (`src/routes/tools/ytdlp/+page.svelte`): the all-duplicates early return still reports success (preserving clear-on-all-skipped), `batchProgress` is reset on failure, and the "queue added" toast count now uses the backend's returned `taskIds.length` so it can't overcount skipped items.
- **metadata-scan#1 — Undownloadable id-only entries poison the whole batch** (`src-tauri/src/ytdlp/metadata/fetch.rs`, `src-tauri/src/ytdlp/download/commands.rs`): `parse_flat_entry` now skips (with a warn log) id-only non-YouTube entries that could never be downloaded, and `add_to_queue_batch` skips invalid items per-entry instead of `?`-failing the entire batch (returning `InvalidUrl` only when nothing is valid) — so one bad entry no longer blocks every valid video in a playlist.
- **error-reporting#1 — Failed downloads completely silent in the app shell** (`src/routes/tools/ytdlp/+layout.svelte`): `error` download events now trigger the previously-dead `showErrorToast` (title resolved before the summary refresh, backend i18n message appended); `cancelled` events stay silent as user-initiated.
- **frontend-stability#2 — Failed items vanish from the queue popup with no indicator** (`src/routes/tools/ytdlp/+layout.svelte`): a failed count is derived client-side via `getActiveQueue` (no `QueueSummary`/bindings change) and shown as a persistent popup line linking to the queue page; the sidebar/footer badges now include failures and switch to the error color when nothing is active.
- **error-reporting#6 — Queue page actions give no feedback on failure** (`src/routes/tools/ytdlp/queue/+page.svelte`): all 7 action handlers (retry/cancel/cancel-all/cancel-group/clear/delete/delete-group) now surface `extractError(r.error)` in a dismissible page banner in both the error-result and thrown-exception paths.
- **frontend-stability#7 — Retry click appears to do nothing when the command fails** (`src/routes/tools/ytdlp/queue/+page.svelte`, `src/routes/tools/ytdlp/+layout.svelte`): the action-error banner is cleared at the start of each action, errors are also `console.error`-logged, and the identical swallow in the layout popup's `handleCancelAll` is fixed with a toast.
- **error-reporting#8 — In-app updater failure is silent** (`src/routes/tools/ytdlp/+layout.svelte`): a new `updateError` state renders the failure inside the update dialog, and `updateReady`/`updateError` are reset at the start of each attempt so retries don't show stale "ready to install" or error text.
- **frontend-stability#4 — Update modal cannot be dismissed while downloading, and auto-relaunch can fire while hidden** (`src/routes/tools/ytdlp/+layout.svelte`): the dialog is now hideable mid-download (re-surfacing when `downloadAndInstall` settles), auto-relaunch is removed entirely in favor of an explicit "Restart now" button with its own failure handling ("restart manually" message), and reopening the sidebar entry clears stale errors.
- **metadata-scan#6 — Stale terminal event from a previous mount kills a new scan** (`src/routes/tools/ytdlp/+page.svelte`): `scanSeq` moved to `<script module>` and seeded with a random u32-safe offset (`Math.floor(Math.random() * 0x7fffffff)`), so scan ids never collide across remounts or webview reloads and a delayed "cancelled" event from a dead scan can no longer end a fresh one early.
- **metadata-scan#9 — Pressing Enter during a streaming scan restarts it from scratch** (`src/routes/tools/ytdlp/+page.svelte`): `handleAnalyze` now no-ops when the requested URL equals the active scan's URL, and the in-field cancel X renders during `analyzing || scanning` so the user can explicitly cancel and rescan — accumulated entries from a long channel scan are no longer thrown away by a reflexive Enter.

New i18n keys (`layout.downloadFailedToast`, `layout.failedCount`, `queue.actionFailed`, `update.failed`, `update.restartNow`, `update.restartManually`, `update.hide`) were added to all 7 locale files. `src/lib/bindings.ts` is untouched — no command, event, or specta type changes.

## Verification

- `cargo fmt` — clean, no diffs
- `cargo clippy -- -D warnings` — pass, no warnings
- `cargo test` — pass (79+ tests, including the updated `parse_flat_entry` test)
- `bun run check` (svelte-check) — pass, no errors
- `bun run build` (vite build) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
