### PR TITLE
fix: surface settings save failures and harden settings persistence

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,6 +133,11 @@ pub fn run() {
             }
             app.manage(Arc::new(db));
 
+            // Recover from a settings.json corrupted by a mid-write crash BEFORE anything
+            // opens the store (first user is setup_tray below): the store plugin silently
+            // loads a broken file as empty and its next save would wipe every setting.
+            ytdlp::settings::recover_corrupt_settings(&app_data_dir);
+
             // Initialize DownloadManager with max_concurrent from settings
             let settings =
                 ytdlp::settings::get_settings_from_path(&app_data_dir).unwrap_or_default();

--- a/src-tauri/src/ytdlp/commands/settings_cmd.rs
+++ b/src-tauri/src/ytdlp/commands/settings_cmd.rs
@@ -43,9 +43,11 @@ pub fn update_settings(app: AppHandle, settings: AppSettings) -> Result<(), AppE
         security::sanitize_proxy(&adv.proxy)?;
     }
 
-    // Clamp max_concurrent to safe range
+    // Clamp max_concurrent and sleep_interval to safe ranges
     let mut settings = settings;
     settings.max_concurrent = security::clamp_max_concurrent(settings.max_concurrent);
+    settings.advanced.sleep_interval =
+        security::clamp_sleep_interval(settings.advanced.sleep_interval);
 
     // Snapshot the dependency-affecting settings to know whether to drop the cache.
     let old = crate::ytdlp::settings::get_settings(&app).ok();
@@ -108,7 +110,7 @@ pub fn get_available_browsers() -> Vec<String> {
 
     #[cfg(target_os = "windows")]
     {
-        let checks: &[(&str, &str)] = &[
+        let mut checks: Vec<(&str, String)> = [
             (
                 "chrome",
                 r"C:\Program Files\Google\Chrome\Application\chrome.exe",
@@ -130,9 +132,40 @@ pub fn get_available_browsers() -> Vec<String> {
                 "brave",
                 r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe",
             ),
-        ];
+            ("opera", r"C:\Program Files\Opera\opera.exe"),
+            (
+                "vivaldi",
+                r"C:\Program Files\Vivaldi\Application\vivaldi.exe",
+            ),
+            (
+                "whale",
+                r"C:\Program Files\Naver\Naver Whale\Application\whale.exe",
+            ),
+        ]
+        .iter()
+        .map(|(name, path)| (*name, path.to_string()))
+        .collect();
 
-        for (name, path) in checks {
+        // Per-user installs: Chrome's default without admin rights, and the usual home of
+        // user-level Edge/Brave/Opera/Vivaldi/Whale setups.
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            for (name, rel) in [
+                ("chrome", r"Google\Chrome\Application\chrome.exe"),
+                ("firefox", r"Mozilla Firefox\firefox.exe"),
+                ("edge", r"Microsoft\Edge\Application\msedge.exe"),
+                (
+                    "brave",
+                    r"BraveSoftware\Brave-Browser\Application\brave.exe",
+                ),
+                ("opera", r"Programs\Opera\opera.exe"),
+                ("vivaldi", r"Vivaldi\Application\vivaldi.exe"),
+                ("whale", r"Naver\Naver Whale\Application\whale.exe"),
+            ] {
+                checks.push((name, format!(r"{}\{}", local, rel)));
+            }
+        }
+
+        for (name, path) in &checks {
             if std::path::Path::new(path).exists() && !browsers.contains(&name.to_string()) {
                 browsers.push(name.to_string());
             }
@@ -150,7 +183,7 @@ pub fn get_available_browsers() -> Vec<String> {
         ];
 
         for (name, path) in checks {
-            if std::path::Path::new(path).exists() {
+            if std::path::Path::new(path).exists() && !browsers.contains(&name.to_string()) {
                 browsers.push(name.to_string());
             }
         }
@@ -158,7 +191,7 @@ pub fn get_available_browsers() -> Vec<String> {
 
     #[cfg(target_os = "linux")]
     {
-        let checks: &[(&str, &str)] = &[
+        let mut checks: Vec<(&str, String)> = [
             ("chrome", "/usr/bin/google-chrome-stable"),
             ("chrome", "/usr/bin/google-chrome"),
             ("chromium", "/usr/bin/chromium-browser"),
@@ -166,9 +199,40 @@ pub fn get_available_browsers() -> Vec<String> {
             ("firefox", "/usr/bin/firefox"),
             ("brave", "/usr/bin/brave-browser"),
             ("edge", "/usr/bin/microsoft-edge"),
-        ];
+            // Snap installs (Ubuntu ships firefox/chromium as snaps by default)
+            ("firefox", "/snap/bin/firefox"),
+            ("chromium", "/snap/bin/chromium"),
+            ("brave", "/snap/bin/brave"),
+            ("opera", "/snap/bin/opera"),
+        ]
+        .iter()
+        .map(|(name, path)| (*name, path.to_string()))
+        .collect();
 
-        for (name, path) in checks {
+        // Flatpak installs: system-wide exports plus the per-user export/app dirs.
+        const FLATPAK_IDS: &[(&str, &str)] = &[
+            ("firefox", "org.mozilla.firefox"),
+            ("chrome", "com.google.Chrome"),
+            ("chromium", "org.chromium.Chromium"),
+            ("brave", "com.brave.Browser"),
+            ("edge", "com.microsoft.Edge"),
+            ("opera", "com.opera.Opera"),
+            ("vivaldi", "com.vivaldi.Vivaldi"),
+        ];
+        for &(name, id) in FLATPAK_IDS {
+            checks.push((name, format!("/var/lib/flatpak/exports/bin/{}", id)));
+        }
+        if let Ok(home) = std::env::var("HOME") {
+            for &(name, id) in FLATPAK_IDS {
+                checks.push((
+                    name,
+                    format!("{}/.local/share/flatpak/exports/bin/{}", home, id),
+                ));
+                checks.push((name, format!("{}/.var/app/{}", home, id)));
+            }
+        }
+
+        for (name, path) in &checks {
             if std::path::Path::new(path).exists() && !browsers.contains(&name.to_string()) {
                 browsers.push(name.to_string());
             }

--- a/src-tauri/src/ytdlp/download/advanced.rs
+++ b/src-tauri/src/ytdlp/download/advanced.rs
@@ -128,7 +128,8 @@ pub fn build_advanced_args(
     }
     if adv.sleep_interval > 0 {
         args.push("--sleep-interval".to_string());
-        args.push(adv.sleep_interval.min(86_400).to_string());
+        // Load-bearing clamp: also sanitizes oversized values persisted before the cap existed.
+        args.push(security::clamp_sleep_interval(adv.sleep_interval).to_string());
     }
 
     // --- Container (video only) ---
@@ -316,6 +317,32 @@ mod tests {
         assert_eq!(
             val_after(&build_advanced_args(&adv, false, true), "--retries"),
             Some(&"100".to_string())
+        );
+    }
+
+    #[test]
+    fn sleep_interval_clamped() {
+        let adv = AdvancedOptions::default();
+        assert!(!has(
+            &build_advanced_args(&adv, false, true),
+            "--sleep-interval"
+        ));
+        let adv = AdvancedOptions {
+            sleep_interval: 30,
+            ..Default::default()
+        };
+        assert_eq!(
+            val_after(&build_advanced_args(&adv, false, true), "--sleep-interval"),
+            Some(&"30".to_string())
+        );
+        // Oversized values persisted before the cap existed must be clamped here too.
+        let adv = AdvancedOptions {
+            sleep_interval: 86_400,
+            ..Default::default()
+        };
+        assert_eq!(
+            val_after(&build_advanced_args(&adv, false, true), "--sleep-interval"),
+            Some(&security::MAX_SLEEP_INTERVAL_SECS.to_string())
         );
     }
 

--- a/src-tauri/src/ytdlp/security.rs
+++ b/src-tauri/src/ytdlp/security.rs
@@ -274,6 +274,16 @@ pub fn clamp_max_concurrent(n: u32) -> u32 {
     n.clamp(1, MAX_CONCURRENT_LIMIT)
 }
 
+/// Maximum --sleep-interval in seconds. Generous for rate-limit avoidance while staying far
+/// below the 6h download timeout (yt-dlp can sleep once per format, so a merged video+audio
+/// download may wait twice). Mirrored by MAX_SLEEP_INTERVAL in src/lib/advanced.ts.
+pub const MAX_SLEEP_INTERVAL_SECS: u32 = 600;
+
+/// Clamp the advanced sleep_interval to [0, MAX_SLEEP_INTERVAL_SECS].
+pub fn clamp_sleep_interval(secs: u32) -> u32 {
+    secs.min(MAX_SLEEP_INTERVAL_SECS)
+}
+
 /// Sanitize error messages before sending to the frontend.
 /// Removes potentially sensitive data: the user's home directory, credential-like URL
 /// query parameters, and OS temp paths that leak the local username or layout.
@@ -613,6 +623,14 @@ mod tests {
         assert_eq!(clamp_max_concurrent(5), 5);
         assert_eq!(clamp_max_concurrent(100), MAX_CONCURRENT_LIMIT);
         assert_eq!(clamp_max_concurrent(u32::MAX), MAX_CONCURRENT_LIMIT);
+    }
+
+    #[test]
+    fn test_clamp_sleep_interval() {
+        assert_eq!(clamp_sleep_interval(0), 0);
+        assert_eq!(clamp_sleep_interval(30), 30);
+        assert_eq!(clamp_sleep_interval(86_400), MAX_SLEEP_INTERVAL_SECS);
+        assert_eq!(clamp_sleep_interval(u32::MAX), MAX_SLEEP_INTERVAL_SECS);
     }
 
     // === Advanced option validators ===

--- a/src-tauri/src/ytdlp/settings.rs
+++ b/src-tauri/src/ytdlp/settings.rs
@@ -1,10 +1,13 @@
 use super::types::{AdvancedOptions, AppSettings};
+use crate::modules::logger;
 use crate::modules::types::AppError;
 use crate::ytdlp::security;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tauri_plugin_store::StoreExt;
 
 const STORE_FILE: &str = "settings.json";
+/// Last known-good copy of settings.json, refreshed after each successful save.
+const BACKUP_FILE: &str = "settings.json.bak";
 
 /// Common parsing logic: extract AppSettings from a key-value getter function.
 /// `getter` takes a key name and returns an optional serde_json::Value.
@@ -212,7 +215,92 @@ pub fn update_settings(app: &AppHandle, settings: &AppSettings) -> Result<(), Ap
 
     store.save().map_err(|e| AppError::Custom(e.to_string()))?;
 
+    // Refresh the last known-good backup now that a full snapshot was saved successfully.
+    if let Ok(app_data_dir) = app.path().app_data_dir() {
+        backup_settings_file(&app_data_dir);
+    }
+
     Ok(())
+}
+
+/// True when the file exists, is readable, and parses as JSON.
+fn parses_as_json(path: &std::path::Path) -> bool {
+    std::fs::read_to_string(path)
+        .map(|content| serde_json::from_str::<serde_json::Value>(&content).is_ok())
+        .unwrap_or(false)
+}
+
+/// Recover from a settings.json corrupted by a crash or power loss mid-save.
+///
+/// Must run BEFORE the first `app.store()` call: tauri-plugin-store ignores load errors, so a
+/// corrupt file silently yields an empty store and the next save would permanently overwrite
+/// every setting with defaults. The corrupt file is quarantined (kept for diagnosis) and the
+/// last known-good backup is restored, but only when the backup itself parses.
+pub fn recover_corrupt_settings(app_data_dir: &std::path::Path) {
+    let settings_path = app_data_dir.join(STORE_FILE);
+    if !settings_path.exists() || parses_as_json(&settings_path) {
+        return;
+    }
+
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let quarantine = app_data_dir.join(format!("{}.corrupt-{}", STORE_FILE, ts));
+    if let Err(e) = std::fs::rename(&settings_path, &quarantine) {
+        logger::warn_cat(
+            "settings",
+            &format!(
+                "settings.json is corrupt but could not be quarantined: {}",
+                e
+            ),
+        );
+        return;
+    }
+    logger::warn_cat(
+        "settings",
+        &format!(
+            "settings.json was corrupt; quarantined as {}",
+            quarantine.display()
+        ),
+    );
+
+    let backup = app_data_dir.join(BACKUP_FILE);
+    if parses_as_json(&backup) {
+        match std::fs::copy(&backup, &settings_path) {
+            Ok(_) => logger::warn_cat("settings", "Restored settings.json from settings.json.bak"),
+            Err(e) => logger::warn_cat(
+                "settings",
+                &format!("Failed to restore settings.json from backup: {}", e),
+            ),
+        }
+    } else {
+        logger::warn_cat(
+            "settings",
+            "No valid settings.json.bak to restore; starting from defaults",
+        );
+    }
+}
+
+/// Refresh the last known-good backup after a successful save: read the just-written file back
+/// and copy it only when it parses, so settings.json.bak is always restorable. Store writes done
+/// outside update_settings (e.g. the dep auto-update throttle timestamp) are not backed up;
+/// losing those on a restore is harmless.
+fn backup_settings_file(app_data_dir: &std::path::Path) {
+    let settings_path = app_data_dir.join(STORE_FILE);
+    if !parses_as_json(&settings_path) {
+        logger::warn_cat(
+            "settings",
+            "Skipping settings backup: settings.json did not read back as valid JSON",
+        );
+        return;
+    }
+    if let Err(e) = std::fs::copy(&settings_path, app_data_dir.join(BACKUP_FILE)) {
+        logger::warn_cat(
+            "settings",
+            &format!("Failed to write settings.json.bak: {}", e),
+        );
+    }
 }
 
 pub fn default_download_path() -> String {
@@ -241,4 +329,72 @@ pub fn get_settings_from_path(app_data_dir: &std::path::Path) -> Result<AppSetti
         .map_err(|e| AppError::Custom(format!("Failed to parse settings: {}", e)))?;
 
     Ok(parse_settings(|key| value.get(key).cloned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "yummy-settings-test-{}-{}",
+            tag,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn recover_quarantines_corrupt_file_and_restores_backup() {
+        let dir = temp_dir("restore");
+        std::fs::write(dir.join(STORE_FILE), "{ truncated").unwrap();
+        std::fs::write(dir.join(BACKUP_FILE), r#"{"downloadPath":"/tmp"}"#).unwrap();
+
+        recover_corrupt_settings(&dir);
+
+        assert_eq!(
+            std::fs::read_to_string(dir.join(STORE_FILE)).unwrap(),
+            r#"{"downloadPath":"/tmp"}"#
+        );
+        let quarantined = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("settings.json.corrupt-")
+            });
+        assert!(quarantined);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn recover_leaves_valid_settings_alone() {
+        let dir = temp_dir("valid");
+        std::fs::write(dir.join(STORE_FILE), r#"{"downloadPath":"/tmp"}"#).unwrap();
+
+        recover_corrupt_settings(&dir);
+
+        assert_eq!(
+            std::fs::read_to_string(dir.join(STORE_FILE)).unwrap(),
+            r#"{"downloadPath":"/tmp"}"#
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn recover_does_not_restore_corrupt_backup() {
+        let dir = temp_dir("badbak");
+        std::fs::write(dir.join(STORE_FILE), "{ truncated").unwrap();
+        std::fs::write(dir.join(BACKUP_FILE), "also broken").unwrap();
+
+        recover_corrupt_settings(&dir);
+
+        // The corrupt main file is quarantined and NOT replaced by the broken backup,
+        // so the store starts from defaults instead of another corrupt file.
+        assert!(!dir.join(STORE_FILE).exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/lib/advanced.ts
+++ b/src/lib/advanced.ts
@@ -31,6 +31,10 @@ export function defaultAdvancedOptions(): AdvancedOptions {
   }
 }
 
+// Upper bound for sleepInterval (seconds). MUST stay in sync with
+// MAX_SLEEP_INTERVAL_SECS in src-tauri/src/ytdlp/security.rs.
+export const MAX_SLEEP_INTERVAL = 600
+
 // Select option metadata shared between the UI and validation.
 export const VIDEO_CODECS = ["auto", "av01", "vp9", "h264"] as const
 export const SPONSORBLOCK_MODES = ["off", "mark", "remove"] as const
@@ -66,6 +70,14 @@ export function validateAdvancedField(field: AdvancedTextField, value: string): 
   if (field === "limitRate") {
     const numeric = v.replace(/[KMGkmg]$/, "")
     if (Number(numeric) <= 0) return false
+  }
+  if (field === "proxy") {
+    // Mirror sanitize_proxy's port range check (security.rs): reject port 0 and > 65535.
+    const port = v.replace(/\/$/, "").match(/:(\d{1,5})$/)?.[1]
+    if (port !== undefined) {
+      const n = Number(port)
+      if (n < 1 || n > 65535) return false
+    }
   }
   return RE[field].test(v)
 }

--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -258,6 +258,8 @@ const de: Record<string, string> = {
   "settings.licensesDesc": "Diese App bündelt oder lädt folgende Open-Source-Tools herunter:",
   "settings.ffmpegGplNotice": "FFmpeg wird unter der GPLv3 vertrieben; der mitgelieferte GPL-Build und sein Quellcode sind über die obigen Projektlinks verfügbar.",
   "settings.openLocation": "Dateispeicherort öffnen",
+  "settings.saveFailed": "Einstellungen konnten nicht gespeichert werden: {error}",
+  "settings.welcomeSaveFailed": "Die Einrichtung konnte nicht gespeichert werden — der Willkommensbildschirm erscheint beim nächsten Start möglicherweise erneut",
 
   // Errors (backend i18n keys)
   "error.privateVideo": "Dies ist ein privates Video und kann nicht aufgerufen werden.",

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -266,6 +266,8 @@ const en: Record<string, string> = {
   "settings.licensesDesc": "This app bundles or downloads these open-source tools:",
   "settings.ffmpegGplNotice": "FFmpeg is distributed under the GPLv3; the bundled GPL build and its source are available from the project links above.",
   "settings.openLocation": "Open file location",
+  "settings.saveFailed": "Failed to save settings: {error}",
+  "settings.welcomeSaveFailed": "Your setup choices could not be saved — the welcome screen may appear again on the next launch",
 
   // Errors (backend i18n keys; see src-tauri metadata/mod.rs, download/executor.rs)
   "error.privateVideo": "This is a private video and can't be accessed.",

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -258,6 +258,8 @@ const fr: Record<string, string> = {
   "settings.licensesDesc": "Cette application intègre ou télécharge les outils open source suivants :",
   "settings.ffmpegGplNotice": "FFmpeg est distribué sous licence GPLv3 ; la version GPL fournie et son code source sont disponibles via les liens de projet ci-dessus.",
   "settings.openLocation": "Ouvrir l'emplacement du fichier",
+  "settings.saveFailed": "Échec de l'enregistrement des paramètres : {error}",
+  "settings.welcomeSaveFailed": "Impossible d'enregistrer la configuration initiale — l'écran de bienvenue pourra réapparaître au prochain démarrage",
 
   // Errors (backend i18n keys)
   "error.privateVideo": "Cette vidéo est privée et inaccessible.",

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -258,6 +258,8 @@ const ja: Record<string, string> = {
   "settings.licensesDesc": "このアプリは以下のオープンソースツールを同梱またはダウンロードします：",
   "settings.ffmpegGplNotice": "FFmpeg は GPLv3 ライセンスで配布されています。同梱の GPL ビルドとそのソースコードは上記プロジェクトリンクから入手できます。",
   "settings.openLocation": "ファイルの場所を開く",
+  "settings.saveFailed": "設定の保存に失敗しました: {error}",
+  "settings.welcomeSaveFailed": "セットアップ内容を保存できませんでした。次回起動時にようこそ画面が再表示される場合があります",
 
   // Errors (backend i18n keys)
   "error.privateVideo": "非公開の動画です。アクセスできません。",

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -258,6 +258,8 @@ const ko: Record<string, string> = {
   "settings.licensesDesc": "이 앱은 다음 오픈소스 도구를 포함하거나 다운로드합니다:",
   "settings.ffmpegGplNotice": "FFmpeg는 GPLv3 라이선스로 배포됩니다. 번들된 GPL 빌드와 소스 코드는 위 프로젝트 링크에서 확인할 수 있습니다.",
   "settings.openLocation": "파일 위치 열기",
+  "settings.saveFailed": "설정 저장에 실패했습니다: {error}",
+  "settings.welcomeSaveFailed": "초기 설정을 저장하지 못했습니다. 다음 실행 시 시작 화면이 다시 표시될 수 있습니다",
 
   // Errors (백엔드 i18n 키; src-tauri metadata/mod.rs, download/executor.rs 참고)
   "error.privateVideo": "비공개 영상입니다. 접근할 수 없습니다.",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -258,6 +258,8 @@ const zhCN: Record<string, string> = {
   "settings.licensesDesc": "本应用内置或下载了以下开源工具：",
   "settings.ffmpegGplNotice": "FFmpeg 遵循 GPLv3 协议发布，内置的 GPL 构建版本及其源代码可通过上方项目链接获取。",
   "settings.openLocation": "打开文件位置",
+  "settings.saveFailed": "设置保存失败：{error}",
+  "settings.welcomeSaveFailed": "初始设置未能保存，下次启动时可能会再次显示欢迎界面",
 
   // Errors (backend i18n keys)
   "error.privateVideo": "这是私享视频，无法访问。",

--- a/src/lib/i18n/locales/zh-TW.ts
+++ b/src/lib/i18n/locales/zh-TW.ts
@@ -258,6 +258,8 @@ const zhTW: Record<string, string> = {
   "settings.licensesDesc": "本應用程式內建或下載了以下開源工具：",
   "settings.ffmpegGplNotice": "FFmpeg 依 GPLv3 授權發布，內建的 GPL 建置版本及其原始碼可透過上方專案連結取得。",
   "settings.openLocation": "開啟檔案位置",
+  "settings.saveFailed": "設定儲存失敗：{error}",
+  "settings.welcomeSaveFailed": "初始設定未能儲存，下次啟動時可能會再次顯示歡迎畫面",
 
   // Errors (backend i18n keys)
   "error.privateVideo": "這是私人影片，無法存取。",

--- a/src/routes/tools/ytdlp/+layout.svelte
+++ b/src/routes/tools/ytdlp/+layout.svelte
@@ -577,15 +577,25 @@
   }
 
   async function handleWelcomeComplete() {
+    // Persisting can fail (tauri-specta Results don't throw, so check the status). Let the
+    // user out of the wizard regardless, but warn them — otherwise the welcome screen
+    // reappears on the next launch with no explanation.
+    let persisted = false
     try {
       const settingsResult = await commands.getSettings()
       if (settingsResult.status === "ok") {
         const updated = { ...settingsResult.data, depMode: selectedDepMode, setupCompleted: true }
-        await commands.updateSettings(updated)
+        const saveResult = await commands.updateSettings(updated)
+        if (saveResult.status === "ok") {
+          persisted = true
+        } else {
+          console.error("Failed to save welcome settings:", saveResult.error)
+        }
       }
     } catch (e) {
       console.error("Failed to save welcome settings:", e)
     }
+    if (!persisted) showErrorToast(t("settings.welcomeSaveFailed"))
     setupCompleted = true
     // Trigger dep check after mode selection
     await checkDeps(true)

--- a/src/routes/tools/ytdlp/+page.svelte
+++ b/src/routes/tools/ytdlp/+page.svelte
@@ -4,6 +4,7 @@
     defaultAdvancedOptions,
     validateAdvancedField,
     type AdvancedTextField,
+    MAX_SLEEP_INTERVAL,
     SPONSORBLOCK_CATEGORIES,
     CONTAINER_FORMATS,
     SUB_CONVERT_FORMATS,
@@ -102,7 +103,6 @@
   let templateUploadDate = $state(false)
   let templateVideoId = $state(false)
   let fullSettings = $state<any>(null)
-  let savingTemplate = $state(false)
 
   // Download state (live progress/cancel lives in the queue popup; this page only enqueues)
   let downloading = $state(false)
@@ -277,18 +277,50 @@
     } catch (e) { console.error("Failed to load settings:", e) }
   }
 
-  async function autoSaveSettings(patch: Record<string, any>) {
-    if (!fullSettings) return
+  // Saves run through a single promise chain so an in-flight save can never be overtaken by a
+  // later one (per-key store writes would otherwise interleave snapshots).
+  let settingsSaveQueue: Promise<void> = Promise.resolve()
+
+  function autoSaveSettings(patch: Record<string, any>): Promise<boolean> {
+    if (!fullSettings) return Promise.resolve(false)
+    // Merge synchronously so rapid consecutive changes build on each other instead of a stale
+    // snapshot whose full-settings save would silently revert the earlier change.
     const updated = { ...fullSettings, ...patch }
-    try {
-      await commands.updateSettings(updated)
-      fullSettings = updated
-    } catch (e) { console.error("Failed to auto-save settings:", e) }
+    fullSettings = updated
+    const save = settingsSaveQueue.then(async () => {
+      // tauri-specta Results don't throw: a rejected save comes back as status "error" and
+      // must be checked, or the UI silently diverges from what's actually persisted.
+      try {
+        const result = await commands.updateSettings(updated)
+        if (result.status === "error") {
+          await reportSettingsSaveError(result.error)
+          return false
+        }
+        return true
+      } catch (e) {
+        console.error("Failed to auto-save settings:", e)
+        await reportSettingsSaveError(e)
+        return false
+      }
+    })
+    settingsSaveQueue = save.then(() => {})
+    return save
   }
 
-  // Persist the advanced options. $state.snapshot unwraps the reactive proxy so Tauri can
-  // serialize a plain object.
+  // A failed save means the UI holds values the backend never accepted: surface the failure in
+  // the error banner and resync every bound control from the persisted settings.
+  async function reportSettingsSaveError(err: unknown) {
+    errorKey = getErrorKey(err)
+    error = t("settings.saveFailed", { error: extractError(err) })
+    await loadSettings()
+  }
+
+  // Persist the advanced options, but only while every free-text field is valid: the backend
+  // rejects the whole snapshot otherwise, which would fail every later save this session.
+  // $state.snapshot unwraps the reactive proxy so Tauri can serialize a plain object.
   function saveAdvanced() {
+    const textFields: AdvancedTextField[] = ["subLangs", "limitRate", "downloadSections", "proxy"]
+    if (!textFields.every((f) => validateAdvancedField(f, advanced[f]))) return
     autoSaveSettings({ advanced: $state.snapshot(advanced) })
   }
 
@@ -316,7 +348,7 @@
   }
 
   function setSleepInterval(v: string) {
-    advanced.sleepInterval = Math.max(0, parseInt(v) || 0)
+    advanced.sleepInterval = Math.max(0, Math.min(MAX_SLEEP_INTERVAL, parseInt(v) || 0))
     saveAdvanced()
   }
 
@@ -329,10 +361,13 @@
     try {
       const result = await commands.selectDownloadDirectory()
       if (result.status === "ok" && result.data) {
-        downloadPath = result.data
-        if (fullSettings) {
-          fullSettings.downloadPath = result.data
-          await commands.updateSettings(fullSettings)
+        const selected = result.data
+        if (!fullSettings) {
+          downloadPath = selected
+        } else if (await autoSaveSettings({ downloadPath: selected })) {
+          // Only show the new folder once the backend accepted it; otherwise downloads
+          // would keep landing in the old folder while the UI claims the new one.
+          downloadPath = selected
         }
       }
     } catch (e) { console.error("Failed to select dir:", e) }
@@ -357,22 +392,16 @@
     return path
   }
 
-  async function saveTemplateSettings() {
-    if (!fullSettings || savingTemplate) return
-    savingTemplate = true
-    try {
-      const updated = {
-        ...fullSettings,
-        useAdvancedTemplate,
-        filenameTemplate: useAdvancedTemplate ? filenameTemplate : buildTemplate(),
-        templateUploaderFolder,
-        templateUploadDate,
-        templateVideoId,
-      }
-      await commands.updateSettings(updated)
-      fullSettings = updated
-    } catch (e) { console.error("Failed to save template settings:", e) }
-    finally { savingTemplate = false }
+  // Rapid consecutive checkbox changes are safe: autoSaveSettings merges synchronously and
+  // serializes the saves, so no change is dropped or based on a stale snapshot.
+  function saveTemplateSettings() {
+    autoSaveSettings({
+      useAdvancedTemplate,
+      filenameTemplate: useAdvancedTemplate ? filenameTemplate : buildTemplate(),
+      templateUploaderFolder,
+      templateUploadDate,
+      templateVideoId,
+    })
   }
 
   function startAnalyzeTimer() {
@@ -1522,7 +1551,7 @@
           </div>
           <div class="flex items-center justify-between gap-3 min-h-[28px]">
             {@render advLabel(t("download.advSleepInterval"), t("download.advSleepIntervalHelp"))}
-            <input type="number" min="0" value={advanced.sleepInterval} oninput={(e) => setSleepInterval(e.currentTarget.value)} class={numCls} />
+            <input type="number" min="0" max={MAX_SLEEP_INTERVAL} value={advanced.sleepInterval} oninput={(e) => setSleepInterval(e.currentTarget.value)} class={numCls} />
           </div>
         </div>
       </section>

--- a/src/routes/tools/ytdlp/settings/+page.svelte
+++ b/src/routes/tools/ytdlp/settings/+page.svelte
@@ -6,6 +6,7 @@
   import { t, setLocale, getLocale, supportedLocales } from "$lib/i18n/index.svelte"
   import { setTheme, getTheme } from "$lib/theme/index.svelte"
   import { themes, themeList, type ThemeId } from "$lib/theme/themes"
+  import { extractError } from "$lib/utils/errors"
 
   let settings = $state<AppSettings>({
     downloadPath: "",
@@ -28,6 +29,7 @@
   })
 
   let loading = $state(true)
+  let saveError = $state<string | null>(null)
 
   onMount(async () => {
     try {
@@ -37,21 +39,38 @@
     loading = false
   })
 
-  async function autoSave() {
-    try { await commands.updateSettings(settings) }
-    catch (e) { console.error("Failed to save settings:", e) }
+  // tauri-specta Results don't throw: check the status so a rejected save is surfaced
+  // instead of the toggle silently reverting on the next launch.
+  async function autoSave(): Promise<boolean> {
+    saveError = null
+    try {
+      const result = await commands.updateSettings(settings)
+      if (result.status === "error") {
+        saveError = t("settings.saveFailed", { error: extractError(result.error) })
+        return false
+      }
+      return true
+    } catch (e) {
+      console.error("Failed to save settings:", e)
+      saveError = t("settings.saveFailed", { error: extractError(e) })
+      return false
+    }
   }
 
   async function handleMinimizeChange(e: Event) {
+    const previous = settings.minimizeToTray
     settings.minimizeToTray = (e.target as HTMLInputElement).checked
-    await autoSave()
+    if (!(await autoSave())) settings.minimizeToTray = previous
   }
 
   async function handleAutoUpdateChange(e: Event) {
+    const previous = settings.autoUpdateYtdlp
     settings.autoUpdateYtdlp = (e.target as HTMLInputElement).checked
-    await autoSave()
+    if (!(await autoSave())) settings.autoUpdateYtdlp = previous
   }
 
+  // Language/theme stay applied locally on a failed save (a hard mid-session revert would be
+  // jarring); the inline notice tells the user the choice won't survive a restart.
   async function handleLanguageChange(locale: string) {
     setLocale(locale)
     settings.language = locale
@@ -71,6 +90,13 @@
   </div>
 {:else}
   <div class="max-w-5xl mx-auto px-8 py-8 space-y-10">
+
+    {#if saveError}
+      <div class="flex items-center gap-2 text-xs text-yt-error bg-yt-error/10 border border-yt-error/30 rounded-md px-3 py-2">
+        <span class="material-symbols-outlined text-[16px]">error</span>
+        <span>{saveError}</span>
+      </div>
+    {/if}
 
     <!-- General Section -->
     <section>

--- a/src/routes/tools/ytdlp/settings/dependencies/+page.svelte
+++ b/src/routes/tools/ytdlp/settings/dependencies/+page.svelte
@@ -196,17 +196,38 @@
     }
   }
 
-  async function autoSave() {
-    try { await commands.updateSettings(settings) }
-    catch (e) { console.error("Failed to save settings:", e) }
+  let saveError = $state<string | null>(null)
+
+  // tauri-specta Results don't throw: check the status so a rejected save is surfaced and
+  // the mode/source picker doesn't show a choice the backend never persisted.
+  async function autoSave(): Promise<boolean> {
+    saveError = null
+    try {
+      const result = await commands.updateSettings(settings)
+      if (result.status === "error") {
+        saveError = t("settings.saveFailed", { error: extractError(result.error) })
+        return false
+      }
+      return true
+    } catch (e) {
+      console.error("Failed to save settings:", e)
+      saveError = t("settings.saveFailed", { error: extractError(e) })
+      return false
+    }
   }
 
   async function handleDepModeChange(mode: string) {
+    const previousMode = settings.depMode
+    const previousOverrides = settings.depOverrides
     settings.depMode = mode
     // The new global mode is authoritative; drop any per-item overrides so a
     // lingering pick doesn't contradict it (e.g. a "system" pin under bundled).
     settings.depOverrides = {}
-    await autoSave()
+    if (!(await autoSave())) {
+      settings.depMode = previousMode
+      settings.depOverrides = previousOverrides
+      return
+    }
     await loadDepStatus(true)
   }
 
@@ -228,8 +249,12 @@
       return
     }
     sourceHint = null
+    const previousOverrides = settings.depOverrides
     settings.depOverrides = { ...(settings.depOverrides ?? {}), [depKey]: source }
-    await autoSave()
+    if (!(await autoSave())) {
+      settings.depOverrides = previousOverrides
+      return
+    }
     await loadDepStatus(true)
   }
 
@@ -271,6 +296,13 @@
   </div>
 {:else}
   <div class="max-w-5xl mx-auto px-8 py-8 space-y-10">
+
+    {#if saveError}
+      <div class="flex items-center gap-2 text-xs text-yt-error bg-yt-error/10 border border-yt-error/30 rounded-md px-3 py-2">
+        <span class="material-symbols-outlined text-[16px]">error</span>
+        <span>{saveError}</span>
+      </div>
+    {/if}
 
     <!-- Dependency Mode -->
     <section>


### PR DESCRIPTION
This PR hardens settings reliability end to end: every `updateSettings` Result is now checked so failed saves are surfaced instead of silently diverging UI state from disk, rapid consecutive changes no longer overwrite each other via stale snapshots, `sleepInterval` is clamped to a sane bound across all layers, browser detection covers per-user/snap/flatpak installs so cookie selection works on common setups, and a corrupt `settings.json` is quarantined and recovered from a known-good backup instead of being silently wiped.

## Fixes

- **Surface settings save failures at every call site** (`error-reporting#5` / `frontend-stability#3` / `settings-config#1`, merged) — `src/routes/tools/ytdlp/+page.svelte`, `src/routes/tools/ytdlp/+layout.svelte`, `src/routes/tools/ytdlp/settings/+page.svelte`, `src/routes/tools/ytdlp/settings/dependencies/+page.svelte`, `src/lib/i18n/locales/*`: tauri-specta error Results were discarded everywhere, so a rejected or failed save (invalid field, disk full, locked file) left the UI showing values that were never persisted and silently reverted on restart; now failures show an error banner/inline notice/toast (new `settings.saveFailed` / `settings.welcomeSaveFailed` keys in all 7 locales), bound controls resync or revert, and the directory picker commits the displayed path only on a confirmed save.
- **Stop stale-snapshot overwrites in autoSaveSettings** (`settings-config#2`) — `src/routes/tools/ytdlp/+page.svelte`: patches are now merged into `fullSettings` synchronously and saves are serialized through a single promise chain (the `saveTemplateSettings` drop-guard that lost rapid template changes was removed), so changing two settings in quick succession no longer makes the second save silently revert the first.
- **Clamp sleepInterval to 600s in all three layers** (`settings-config#7`) — `src/routes/tools/ytdlp/+page.svelte`, `src/lib/advanced.ts`, `src-tauri/src/ytdlp/security.rs`, `src-tauri/src/ytdlp/commands/settings_cmd.rs`, `src-tauri/src/ytdlp/download/advanced.rs`: a mistyped sleep interval (e.g. 7200) could make downloads sit at 0% for hours or always hit the 6h timeout; the UI input, `update_settings`, and the load-bearing executor clamp (lowered from 86,400s) now consistently cap it, with Rust tests for the new bound.
- **Detect per-user, snap, and flatpak browser installs** (`settings-config#5`) — `src-tauri/src/ytdlp/commands/settings_cmd.rs`: users with per-user Chrome/Edge/Brave/Firefox on Windows (`%LOCALAPPDATA%`), Opera/Vivaldi/Whale, or snap/flatpak browsers on Linux could not select their browser for cookies at all, permanently blocking age-restricted/member videos; detection now covers those paths (plus a missing macOS dedupe guard).
- **Recover from a corrupt settings.json instead of wiping it** (`settings-config#6`) — `src-tauri/src/ytdlp/settings.rs`, `src-tauri/src/lib.rs`, `src-tauri/src/ytdlp/commands/settings_cmd.rs`: a crash mid-save truncated `settings.json` and the next launch silently reset every setting (download path, language, theme, welcome wizard); startup now quarantines the bad file as `settings.json.corrupt-<ts>` and restores a validated `settings.json.bak`, which is refreshed (read-back + JSON-validated) after each successful save, all logged for diagnosis.
- **Align frontend proxy validation with the backend** (part of the merged save-failure finding) — `src/lib/advanced.ts`: the proxy field now rejects port 0/65536+ exactly like `sanitize_proxy`, and `saveAdvanced` is gated on all four free-text validators so backend rejections are prevented at the source.

## Verification

- `cargo fmt` — clean
- `cargo clippy -- -D warnings` — no warnings
- `cargo test` — 84 tests passing (including new sleep-interval clamp tests in `advanced.rs` and `security.rs`)
- `bun run check` (svelte-check) — passing
- `bun run build` (vite build) — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
