### PR TITLE
fix: atomic dependency installs, network timeouts, verified binaries, and download-aware updates

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -153,6 +153,12 @@ pub fn run() {
                 );
             }
 
+            // Sweep leftover install artifacts (partial archives, staging trees, stale
+            // backups) before anything can start a new install. This must run here —
+            // not inside the install path — because installs for different dependencies
+            // run concurrently and a sweep there could delete an in-flight temp file.
+            ytdlp::dep_download::sweep_install_leftovers(app.handle());
+
             // Seed bundled yt-dlp/ffmpeg into app_data_dir/bin before warmup/dep checks.
             // Runs from a writable copy so `yt-dlp --update` keeps working; deno stays dynamic.
             ytdlp::dep_seed::seed_bundled_binaries(app.handle());

--- a/src-tauri/src/ytdlp/binary/dep_check.rs
+++ b/src-tauri/src/ytdlp/binary/dep_check.rs
@@ -3,7 +3,9 @@ use super::resolve::{
     app_managed_binary, app_managed_ytdlp_binary, check_deno_version, check_ffmpeg, check_ytdlp,
     deno_home_path, deno_on_system_path, try_get_version, which_first,
 };
+use crate::ytdlp::dep_download::{probe_binary_version, VersionProbeError};
 use crate::ytdlp::types::{DepInfo, DepSource, FullDependencyStatus};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 use tauri::AppHandle;
@@ -18,12 +20,28 @@ struct DepStatusCache {
 static DEP_CACHE: std::sync::LazyLock<RwLock<Option<DepStatusCache>>> =
     std::sync::LazyLock::new(|| RwLock::new(None));
 
+/// Result of the last app-managed ffmpeg probe, consulted by the resolver so a
+/// known-broken app copy is never passed to yt-dlp via `--ffmpeg-location`.
+/// Reset to unknown by `invalidate_dep_cache` (which runs after every
+/// install/update/delete), so a fresh install is picked up immediately.
+const FFMPEG_PROBE_UNKNOWN: u8 = 0;
+const FFMPEG_PROBE_OK: u8 = 1;
+const FFMPEG_PROBE_BROKEN: u8 = 2;
+static APP_FFMPEG_PROBE: AtomicU8 = AtomicU8::new(FFMPEG_PROBE_UNKNOWN);
+
+/// True when the last dependency check found the app-managed ffmpeg broken
+/// (hard probe failure — not a mere timeout).
+pub(super) fn app_ffmpeg_probe_broken() -> bool {
+    APP_FFMPEG_PROBE.load(Ordering::Relaxed) == FFMPEG_PROBE_BROKEN
+}
+
 /// Invalidate the dependency status cache.
 /// Called after install/delete/update operations or dep_mode changes.
 pub fn invalidate_dep_cache() {
     if let Ok(mut guard) = DEP_CACHE.write() {
         *guard = None;
     }
+    APP_FFMPEG_PROBE.store(FFMPEG_PROBE_UNKNOWN, Ordering::Relaxed);
 }
 
 /// Quick check if a binary exists on the augmented PATH using which/where.
@@ -36,6 +54,7 @@ async fn quick_binary_exists(name: &str) -> bool {
     };
     let mut cmd = command_with_path(which_cmd);
     cmd.arg(name);
+    cmd.kill_on_drop(true);
 
     #[cfg(target_os = "windows")]
     {
@@ -73,19 +92,22 @@ fn choose_dep(
 
     let mut active: Option<DepInfo> = None;
     for src in source_order(app, dep) {
-        match src {
-            DepSourcePref::AppManaged => {
-                if let Some(info) = &app_info {
-                    active = Some(info.clone());
-                    break;
-                }
-            }
-            DepSourcePref::SystemPath => {
-                if let Some(info) = &system_info {
-                    active = Some(info.clone());
-                    break;
-                }
-            }
+        let candidate = match src {
+            DepSourcePref::AppManaged => app_info.as_ref(),
+            DepSourcePref::SystemPath => system_info.as_ref(),
+        };
+        let Some(info) = candidate else {
+            continue;
+        };
+        // A broken (not-installed) candidate never wins over a working one later
+        // in the order, but is still surfaced when nothing works so the UI can
+        // show the broken copy and offer a reinstall.
+        if info.installed {
+            active = Some(info.clone());
+            break;
+        }
+        if active.is_none() {
+            active = Some(info.clone());
         }
     }
 
@@ -135,29 +157,32 @@ async fn check_dep_ytdlp(app: &AppHandle) -> DepInfo {
 }
 
 /// app-managed ffmpeg, if the binary exists in the app bin dir.
+///
+/// A hard probe failure (spawn error, non-zero exit, no output) means the
+/// on-disk copy is broken — report it as NOT installed, keeping path and
+/// app_available so the UI can show the broken copy and offer a reinstall. A
+/// timeout stays lenient (installed, no version): a cold or loaded machine must
+/// not re-trigger the first-run install gate via the persisted dep cache.
 async fn app_managed_ffmpeg(app: &AppHandle) -> Option<DepInfo> {
     let app_binary = app_managed_binary(app, "ffmpeg", "ffmpeg.exe")?;
 
-    let mut version: Option<String> = None;
-    let mut cmd = tokio::process::Command::new(&app_binary);
-    cmd.arg("-version");
-    #[cfg(target_os = "windows")]
-    {
-        cmd.creation_flags(0x08000000);
-    }
-    if let Ok(Ok(output)) = tokio::time::timeout(Duration::from_secs(5), cmd.output()).await {
-        if output.status.success() {
-            version = Some(
-                String::from_utf8_lossy(&output.stdout)
-                    .lines()
-                    .next()
-                    .unwrap_or("")
-                    .to_string(),
-            );
-        }
-    }
+    let (installed, version) =
+        match probe_binary_version(&app_binary, "-version", Duration::from_secs(5)).await {
+            Ok(v) => {
+                APP_FFMPEG_PROBE.store(FFMPEG_PROBE_OK, Ordering::Relaxed);
+                (true, Some(v))
+            }
+            Err(VersionProbeError::Timeout(_)) => {
+                APP_FFMPEG_PROBE.store(FFMPEG_PROBE_UNKNOWN, Ordering::Relaxed);
+                (true, None)
+            }
+            Err(_) => {
+                APP_FFMPEG_PROBE.store(FFMPEG_PROBE_BROKEN, Ordering::Relaxed);
+                (false, None)
+            }
+        };
     Some(DepInfo {
-        installed: true,
+        installed,
         version,
         source: DepSource::AppManaged,
         path: Some(app_binary.to_string_lossy().to_string()),
@@ -185,11 +210,19 @@ async fn check_dep_ffmpeg(app: &AppHandle) -> DepInfo {
 }
 
 /// app-managed deno, if the binary exists in the app bin dir.
+///
+/// Mirrors `app_managed_ffmpeg`: only a hard probe failure flips installed to
+/// false; a timeout stays lenient.
 async fn app_managed_deno(app: &AppHandle) -> Option<DepInfo> {
     let app_binary = app_managed_binary(app, "deno", "deno.exe")?;
-    let version = check_deno_version(&app_binary).await;
+    let (installed, version) =
+        match probe_binary_version(&app_binary, "--version", Duration::from_secs(10)).await {
+            Ok(v) => (true, Some(v)),
+            Err(VersionProbeError::Timeout(_)) => (true, None),
+            Err(_) => (false, None),
+        };
     Some(DepInfo {
-        installed: true,
+        installed,
         version,
         source: DepSource::AppManaged,
         path: Some(app_binary.to_string_lossy().to_string()),
@@ -289,6 +322,7 @@ pub fn warmup_ytdlp(app: AppHandle) {
         };
         let mut cmd = super::path::command_with_path_app(&path, &app);
         cmd.arg("--version");
+        cmd.kill_on_drop(true);
 
         #[cfg(target_os = "windows")]
         {

--- a/src-tauri/src/ytdlp/binary/resolve.rs
+++ b/src-tauri/src/ytdlp/binary/resolve.rs
@@ -8,6 +8,7 @@ use tauri::AppHandle;
 pub(super) async fn try_get_version(binary_path: &Path) -> Result<String, String> {
     let mut cmd = command_with_path(binary_path.to_str().unwrap_or("yt-dlp"));
     cmd.arg("--version");
+    cmd.kill_on_drop(true);
 
     #[cfg(target_os = "windows")]
     {
@@ -70,6 +71,7 @@ pub(super) async fn which_first(name: &str) -> Option<String> {
     };
     let mut cmd = command_with_path(which_cmd);
     cmd.arg(name);
+    cmd.kill_on_drop(true);
 
     #[cfg(target_os = "windows")]
     {
@@ -137,6 +139,7 @@ pub async fn check_ytdlp() -> (Option<String>, Vec<String>) {
 pub async fn check_ffmpeg() -> Option<String> {
     let mut cmd = command_with_path("ffmpeg");
     cmd.arg("-version");
+    cmd.kill_on_drop(true);
 
     #[cfg(target_os = "windows")]
     {
@@ -162,6 +165,7 @@ pub async fn check_ffmpeg() -> Option<String> {
 pub async fn resolve_ffmpeg_path() -> Option<String> {
     let mut cmd = command_with_path("ffmpeg");
     cmd.arg("-version");
+    cmd.kill_on_drop(true);
 
     #[cfg(target_os = "windows")]
     {
@@ -182,6 +186,7 @@ pub async fn resolve_ffmpeg_path() -> Option<String> {
         };
         let mut which = command_with_path(which_cmd);
         which.arg("ffmpeg");
+        which.kill_on_drop(true);
 
         #[cfg(target_os = "windows")]
         {
@@ -300,8 +305,16 @@ pub async fn resolve_ytdlp_path_with_app(app: &AppHandle) -> Result<String, AppE
 
 /// Resolve the ffmpeg directory (for `--ffmpeg-location`) per the effective source order.
 pub async fn resolve_ffmpeg_path_with_app(app: &AppHandle) -> Option<String> {
-    let app_dir = app_managed_binary(app, "ffmpeg", "ffmpeg.exe")
-        .and_then(|p| p.parent().map(|d| d.to_string_lossy().to_string()));
+    // Skip an app-managed copy the last dependency check found broken — passing a
+    // dead ffmpeg via --ffmpeg-location would fail every merge even when a working
+    // system copy exists. The marker resets on invalidate_dep_cache() (run after
+    // every install/update/delete), so a fresh install is picked up immediately.
+    let app_dir = if super::dep_check::app_ffmpeg_probe_broken() {
+        None
+    } else {
+        app_managed_binary(app, "ffmpeg", "ffmpeg.exe")
+            .and_then(|p| p.parent().map(|d| d.to_string_lossy().to_string()))
+    };
     let system_dir = resolve_ffmpeg_path().await;
 
     for src in source_order(app, "ffmpeg") {
@@ -344,6 +357,7 @@ pub(super) async fn deno_on_system_path() -> Option<PathBuf> {
     };
     let mut cmd = command_with_path(which_cmd);
     cmd.arg("deno");
+    cmd.kill_on_drop(true);
 
     #[cfg(target_os = "windows")]
     {
@@ -371,6 +385,7 @@ pub(super) async fn deno_on_system_path() -> Option<PathBuf> {
 pub async fn check_deno_version(deno_path: &Path) -> Option<String> {
     let mut cmd = super::path::command_with_path(deno_path.to_str().unwrap_or("deno"));
     cmd.arg("--version");
+    cmd.kill_on_drop(true);
 
     #[cfg(target_os = "windows")]
     {
@@ -407,15 +422,23 @@ pub async fn update_ytdlp(app: &AppHandle) -> Result<String, AppError> {
 
     let mut cmd = command_with_path(&ytdlp_path);
     cmd.arg("--update");
+    cmd.kill_on_drop(true);
 
     #[cfg(target_os = "windows")]
     {
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     }
 
-    let output = cmd
-        .output()
+    // `--update` downloads a full binary, so allow generous time — but never hang
+    // forever: an unbounded stall here would leave the update UI spinning until
+    // the app is restarted.
+    let output = tokio::time::timeout(Duration::from_secs(300), cmd.output())
         .await
+        .map_err(|_| {
+            AppError::DependencyInstallError(
+                "yt-dlp --update timed out after 5 minutes".to_string(),
+            )
+        })?
         .map_err(|e| AppError::Custom(format!("Failed to update yt-dlp: {}", e)))?;
 
     if output.status.success() {

--- a/src-tauri/src/ytdlp/commands/dependency.rs
+++ b/src-tauri/src/ytdlp/commands/dependency.rs
@@ -197,28 +197,56 @@ pub async fn update_dependency(app: AppHandle, dep_name: String) -> Result<Strin
 pub async fn delete_app_managed_dep(app: AppHandle, dep_name: String) -> Result<String, AppError> {
     let bin_dir = crate::ytdlp::dep_download::ensure_bin_dir(&app)?;
 
+    // Each list also covers install leftovers (staging trees, stale backups,
+    // partial archives) so "Delete Binary" really clears everything on disk.
     let names_to_delete: Vec<&str> = match dep_name.as_str() {
         "yt-dlp" => {
             // The onedir tree lives under bin/ytdlp/; the bare file is only present
             // for legacy installs. Try both so a delete fully clears yt-dlp.
             if cfg!(target_os = "windows") {
-                vec!["ytdlp", "yt-dlp.exe"]
+                vec![
+                    "ytdlp",
+                    "ytdlp.old",
+                    "ytdlp.staging",
+                    "yt-dlp-onedir.zip.tmp",
+                    "yt-dlp.exe",
+                ]
             } else {
-                vec!["ytdlp", "yt-dlp"]
+                vec![
+                    "ytdlp",
+                    "ytdlp.old",
+                    "ytdlp.staging",
+                    "yt-dlp-onedir.zip.tmp",
+                    "yt-dlp",
+                ]
             }
         }
         "ffmpeg" => {
             if cfg!(target_os = "windows") {
-                vec!["ffmpeg.exe", "ffprobe.exe"]
+                vec![
+                    "ffmpeg.exe",
+                    "ffprobe.exe",
+                    "ffmpeg.staging",
+                    "ffmpeg_archive.zip",
+                    "ffmpeg_archive.tar.gz",
+                    "ffmpeg_archive.tar.xz",
+                ]
             } else {
-                vec!["ffmpeg", "ffprobe"]
+                vec![
+                    "ffmpeg",
+                    "ffprobe",
+                    "ffmpeg.staging",
+                    "ffmpeg_archive.zip",
+                    "ffmpeg_archive.tar.gz",
+                    "ffmpeg_archive.tar.xz",
+                ]
             }
         }
         "deno" => {
             if cfg!(target_os = "windows") {
-                vec!["deno.exe"]
+                vec!["deno.exe", "deno.staging", "deno_archive.zip"]
             } else {
-                vec!["deno"]
+                vec!["deno", "deno.staging", "deno_archive.zip"]
             }
         }
         _ => {

--- a/src-tauri/src/ytdlp/dep_autoupdate.rs
+++ b/src-tauri/src/ytdlp/dep_autoupdate.rs
@@ -9,7 +9,9 @@
 
 use crate::modules::logger;
 use crate::ytdlp::binary::invalidate_dep_cache;
-use crate::ytdlp::dep_download::{ensure_bin_dir, get_binary_version};
+use crate::ytdlp::dep_download::{
+    downloads_busy, ensure_bin_dir, get_binary_version, is_downloads_busy_error,
+};
 use crate::ytdlp::{dep_deno, dep_ffmpeg, dep_ytdlp};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -46,6 +48,19 @@ pub fn auto_update_bundled_deps(app: &AppHandle) {
         record_check_time(&app);
         logger::info_cat("dependency", "Startup dependency auto-update check");
 
+        // Never mutate binaries while downloads are running or queued: the startup
+        // queue resume kicks in ~300ms after launch, so pending rows count as busy
+        // even before active_count moves. Skip and rewind the throttle stamp so the
+        // next launch retries instead of silently deferring a full day.
+        if downloads_busy(&app) {
+            logger::info_cat(
+                "dependency",
+                "Skipping dependency auto-update: downloads are active or queued",
+            );
+            clear_check_time(&app);
+            return;
+        }
+
         update_ytdlp_if_outdated(&app).await;
         refresh_if_aged(&app, "deno", "deno.exe").await;
         refresh_if_aged(&app, "ffmpeg", "ffmpeg.exe").await;
@@ -79,6 +94,15 @@ fn throttled(app: &AppHandle) -> bool {
 fn record_check_time(app: &AppHandle) {
     if let Ok(store) = app.store(STORE_FILE) {
         store.set(THROTTLE_KEY, serde_json::json!(now_secs()));
+        let _ = store.save();
+    }
+}
+
+/// Rewind the throttle stamp after a busy-skip so the next launch retries
+/// immediately instead of waiting out the full 24h window.
+fn clear_check_time(app: &AppHandle) {
+    if let Ok(store) = app.store(STORE_FILE) {
+        store.delete(THROTTLE_KEY);
         let _ = store.save();
     }
 }
@@ -141,7 +165,13 @@ async fn update_ytdlp_if_outdated(app: &AppHandle) {
     );
     match dep_ytdlp::install_ytdlp(app).await {
         Ok(v) => logger::info_cat("dependency", &format!("yt-dlp auto-updated to {v}")),
-        Err(e) => logger::warn_cat("dependency", &format!("yt-dlp auto-update failed: {e}")),
+        Err(e) => {
+            // A download that started mid-install is a deferral, not a failure.
+            if is_downloads_busy_error(&e) {
+                clear_check_time(app);
+            }
+            logger::warn_cat("dependency", &format!("yt-dlp auto-update failed: {e}"));
+        }
     }
 }
 
@@ -166,6 +196,10 @@ async fn refresh_if_aged(app: &AppHandle, unix_name: &str, windows_name: &str) {
         _ => return,
     };
     if let Err(e) = result {
+        // A download that started mid-install is a deferral, not a failure.
+        if is_downloads_busy_error(&e) {
+            clear_check_time(app);
+        }
         logger::warn_cat(
             "dependency",
             &format!("{unix_name} auto-update failed: {e}"),

--- a/src-tauri/src/ytdlp/dep_deno.rs
+++ b/src-tauri/src/ytdlp/dep_deno.rs
@@ -64,42 +64,85 @@ pub async fn install_deno(app: &AppHandle) -> Result<String, AppError> {
         return Err(e);
     }
 
-    // Extract (deno binary is at zip root)
+    // Extract into a staging directory (deno binary is at the zip root), never
+    // directly over the live binary: File::create would truncate a working deno,
+    // so an interrupted extraction must land in a disposable location.
     emit_stage(
         app,
         "deno",
         DepInstallStage::Extracting,
         Some("Extracting deno..."),
     );
-    let extracted = extract_zip(&archive_path, &bin_dir, &[binary_name]).await?;
-
-    if extracted.is_empty() {
+    let staging = bin_dir.join("deno.staging");
+    let _ = std::fs::remove_dir_all(&staging);
+    if let Err(e) = std::fs::create_dir_all(&staging) {
         let _ = tokio::fs::remove_file(&archive_path).await;
+        return Err(AppError::DependencyInstallError(format!(
+            "Failed to create staging dir: {}",
+            e
+        )));
+    }
+    let extract_result = extract_zip(&archive_path, &staging, &[binary_name]).await;
+    // The archive is no longer needed whether or not extraction worked.
+    let _ = tokio::fs::remove_file(&archive_path).await;
+    let extracted = match extract_result {
+        Ok(files) => files,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e);
+        }
+    };
+
+    let staged_deno = staging.join(binary_name);
+    if extracted.is_empty() || !staged_deno.exists() {
+        let _ = std::fs::remove_dir_all(&staging);
         return Err(AppError::DependencyInstallError(
             "deno binary not found in archive".to_string(),
         ));
     }
 
-    // Set executable + remove quarantine
-    for path in &extracted {
-        set_executable(path)?;
-        remove_quarantine(path)?;
+    // Executable bit + quarantine strip happen on the STAGED file, before the
+    // version probe (which needs to run it) and the swap.
+    if let Err(e) = set_executable(&staged_deno) {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(e);
     }
+    let _ = remove_quarantine(&staged_deno);
 
-    // Clean up archive
-    let _ = tokio::fs::remove_file(&archive_path).await;
-
-    // Verify installation
+    // Verify the STAGED binary before swapping: a binary that cannot run must
+    // never report a successful install (or replace a working copy).
     emit_stage(
         app,
         "deno",
-        DepInstallStage::Completing,
+        DepInstallStage::Verifying,
         Some("Verifying installation..."),
     );
-    let deno_path = bin_dir.join(binary_name);
-    let version = get_binary_version(&deno_path, "--version")
-        .await
-        .unwrap_or_else(|| "unknown".to_string());
+    let version = match verify_staged_binary(&staged_deno, "--version").await {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&staging);
+            emit_stage(app, "deno", DepInstallStage::Failed, Some(&e.to_string()));
+            return Err(e);
+        }
+    };
+
+    // Last-moment gate under the dependency lock: never swap the binary while a
+    // download could be running it (yt-dlp spawns deno for some extractors).
+    if downloads_busy(app) {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(downloads_busy_error());
+    }
+
+    // `std::fs::rename` replaces an existing destination; if the target is locked
+    // by a running process the rename fails and the old binary is left untouched.
+    if let Err(e) = std::fs::rename(&staged_deno, bin_dir.join(binary_name)) {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(AppError::DependencyInstallError(format!(
+            "Failed to install deno: {}",
+            e
+        )));
+    }
+    let _ = std::fs::remove_dir_all(&staging);
 
     emit_stage(
         app,
@@ -113,8 +156,7 @@ pub async fn install_deno(app: &AppHandle) -> Result<String, AppError> {
 
 /// Get the latest deno version from GitHub API.
 pub async fn get_latest_version() -> Result<String, AppError> {
-    let client = reqwest::Client::new();
-    let resp = client
+    let resp = short_http_client()
         .get("https://api.github.com/repos/denoland/deno/releases/latest")
         .header("User-Agent", "yummy-yt-dlp")
         .send()

--- a/src-tauri/src/ytdlp/dep_download.rs
+++ b/src-tauri/src/ytdlp/dep_download.rs
@@ -1,10 +1,12 @@
 use super::types::{DepInstallEvent, DepInstallStage};
+use crate::modules::logger;
 use crate::modules::types::AppError;
 use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
@@ -30,6 +32,113 @@ pub async fn lock_dependency(dep: &str) -> OwnedMutexGuard<()> {
     lock.lock_owned().await
 }
 
+/// Shared HTTP client for large archive downloads. `connect_timeout` bounds the
+/// handshake and `read_timeout` bounds idle-between-bytes, so a stalled TCP
+/// connection errors out instead of holding the per-dependency lock forever.
+/// Deliberately no overall deadline: the archives are tens of MB and a slow but
+/// progressing download must not be aborted.
+static DOWNLOAD_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(20))
+        .read_timeout(Duration::from_secs(60))
+        .build()
+        .unwrap_or_default()
+});
+
+/// Shared HTTP client for small checksum/version fetches, with a short overall
+/// deadline — these responses are a few KB, so 30s covers any healthy network.
+static SHORT_HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap_or_default()
+});
+
+/// Client for small dependency HTTP calls (checksums, GitHub `releases/latest`).
+pub(crate) fn short_http_client() -> &'static reqwest::Client {
+    &SHORT_HTTP_CLIENT
+}
+
+/// Shared marker message for "install/update refused because downloads are active".
+/// `dep_autoupdate` matches on it (via `is_downloads_busy_error`) to rewind its
+/// throttle stamp so the next launch retries instead of waiting a full day.
+pub(crate) const DOWNLOADS_BUSY_MSG: &str =
+    "cannot install or update while downloads are running; retry once the queue is idle";
+
+pub fn downloads_busy_error() -> AppError {
+    AppError::DependencyInstallError(DOWNLOADS_BUSY_MSG.to_string())
+}
+
+/// Whether an install error is the downloads-busy refusal (vs a real failure).
+pub(crate) fn is_downloads_busy_error(e: &AppError) -> bool {
+    matches!(e, AppError::DependencyInstallError(msg) if msg == DOWNLOADS_BUSY_MSG)
+}
+
+/// True when any download is running or still queued. Binary mutation (swapping
+/// yt-dlp/ffmpeg/deno) must not race a running or about-to-start download, and
+/// the 300ms-delayed startup resume means `active_count` alone is not enough —
+/// pending queue rows count as busy too.
+pub fn downloads_busy(app: &AppHandle) -> bool {
+    if let Some(manager) = app.try_state::<crate::DownloadManagerState>() {
+        if manager.active_count() > 0 {
+            return true;
+        }
+    }
+    if let Some(db) = app.try_state::<crate::DbState>() {
+        return db
+            .get_cancellable_ids()
+            .map(|ids| !ids.is_empty())
+            .unwrap_or(false);
+    }
+    false
+}
+
+/// Remove leftover install artifacts from `bin/`: partial archive downloads,
+/// staging trees from interrupted installs, and stale `.old` backups.
+///
+/// Must run once at app startup, before any install can begin. It must NOT run
+/// inside the install path (e.g. `ensure_bin_dir`): installs for different
+/// dependencies run concurrently under per-dependency locks, so a sweep there
+/// could delete another dependency's in-flight temp download.
+pub fn sweep_install_leftovers(app: &AppHandle) {
+    let Ok(bin_dir) = ensure_bin_dir(app) else {
+        return;
+    };
+    const LEFTOVERS: &[&str] = &[
+        "yt-dlp-onedir.zip.tmp",
+        "ffmpeg_archive.zip",
+        "ffmpeg_archive.tar.gz",
+        "ffmpeg_archive.tar.xz",
+        "deno_archive.zip",
+        "ytdlp.staging",
+        "ytdlp.old",
+        "ffmpeg.staging",
+        "deno.staging",
+    ];
+    for name in LEFTOVERS {
+        let path = bin_dir.join(name);
+        if !path.exists() {
+            continue;
+        }
+        let result = if path.is_dir() {
+            std::fs::remove_dir_all(&path)
+        } else {
+            std::fs::remove_file(&path)
+        };
+        match result {
+            Ok(()) => logger::info_cat(
+                "dependency",
+                &format!("Removed leftover install artifact {}", name),
+            ),
+            Err(e) => logger::warn_cat(
+                "dependency",
+                &format!("Failed to remove leftover install artifact {}: {}", name, e),
+            ),
+        }
+    }
+}
+
 /// Ensure the `app_data_dir/bin/` directory exists and return its path.
 pub fn ensure_bin_dir(app: &AppHandle) -> Result<PathBuf, AppError> {
     let app_data = app.path().app_data_dir().map_err(|e| {
@@ -52,9 +161,10 @@ pub async fn download_file(
 ) -> Result<PathBuf, AppError> {
     let dest_path = dest_dir.join(temp_name);
 
-    let response = reqwest::get(url)
-        .await
-        .map_err(|e| AppError::DependencyInstallError(format!("Download request failed: {}", e)))?;
+    let response =
+        DOWNLOAD_CLIENT.get(url).send().await.map_err(|e| {
+            AppError::DependencyInstallError(format!("Download request failed: {}", e))
+        })?;
 
     if !response.status().is_success() {
         return Err(AppError::DependencyInstallError(format!(
@@ -83,9 +193,19 @@ pub async fn download_file(
     use tokio::io::AsyncWriteExt;
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| {
-            AppError::DependencyInstallError(format!("Download stream error: {}", e))
-        })?;
+        // On every abort path, drop the handle before deleting the partial file:
+        // Windows refuses to remove a file with an open handle.
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                drop(file);
+                let _ = tokio::fs::remove_file(&dest_path).await;
+                return Err(AppError::DependencyInstallError(format!(
+                    "Download stream error: {}",
+                    e
+                )));
+            }
+        };
 
         downloaded += chunk.len() as u64;
         if downloaded > MAX_DOWNLOAD_BYTES {
@@ -97,9 +217,14 @@ pub async fn download_file(
             )));
         }
 
-        file.write_all(&chunk)
-            .await
-            .map_err(|e| AppError::DependencyInstallError(format!("Write error: {}", e)))?;
+        if let Err(e) = file.write_all(&chunk).await {
+            drop(file);
+            let _ = tokio::fs::remove_file(&dest_path).await;
+            return Err(AppError::DependencyInstallError(format!(
+                "Write error: {}",
+                e
+            )));
+        }
 
         let (percent, should_emit) = match total_size {
             Some(total) if total > 0 => {
@@ -129,9 +254,14 @@ pub async fn download_file(
         }
     }
 
-    file.flush()
-        .await
-        .map_err(|e| AppError::DependencyInstallError(format!("Flush error: {}", e)))?;
+    if let Err(e) = file.flush().await {
+        drop(file);
+        let _ = tokio::fs::remove_file(&dest_path).await;
+        return Err(AppError::DependencyInstallError(format!(
+            "Flush error: {}",
+            e
+        )));
+    }
 
     Ok(dest_path)
 }
@@ -166,7 +296,9 @@ pub async fn verify_sha256(file_path: &Path, expected_hash: &str) -> Result<(), 
 /// Fetch and parse the SHA2-256SUMS file from yt-dlp releases.
 pub async fn fetch_ytdlp_checksums() -> Result<Vec<(String, String)>, AppError> {
     let url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/SHA2-256SUMS";
-    let text = reqwest::get(url)
+    let text = short_http_client()
+        .get(url)
+        .send()
         .await
         .map_err(|e| AppError::DependencyInstallError(format!("Failed to fetch checksums: {}", e)))?
         .text()
@@ -194,7 +326,9 @@ pub async fn fetch_checksum_for(
     manifest_url: &str,
     filename: &str,
 ) -> Result<Option<String>, AppError> {
-    let text = reqwest::get(manifest_url)
+    let text = short_http_client()
+        .get(manifest_url)
+        .send()
         .await
         .map_err(|e| AppError::ChecksumError(format!("failed to fetch checksum manifest: {}", e)))?
         .error_for_status()
@@ -222,7 +356,9 @@ pub async fn fetch_checksum_for(
 /// Fetch a sibling `<asset>.sha256sum` file and return the lowercase hex hash.
 /// The file format is `<sha256>  <filename>`, so the leading token is the hash.
 pub async fn fetch_sha256sum(url: &str) -> Result<String, AppError> {
-    let text = reqwest::get(url)
+    let text = short_http_client()
+        .get(url)
+        .send()
         .await
         .map_err(|e| AppError::ChecksumError(format!("failed to fetch checksum: {}", e)))?
         .error_for_status()
@@ -592,32 +728,95 @@ pub fn finalize_dir(staging_dir: &Path, final_dir: &Path) -> Result<(), AppError
     }
 }
 
-/// Get the version string from a binary by running it with a version flag.
-pub async fn get_binary_version(binary_path: &Path, version_flag: &str) -> Option<String> {
+/// Why a binary version probe failed — lets callers distinguish a slow cold
+/// start (timeout) from a binary that cannot run at all (spawn error, non-zero
+/// exit, empty output).
+#[derive(Debug)]
+pub enum VersionProbeError {
+    Timeout(u64),
+    Spawn(String),
+    Exit { status: String, stderr: String },
+    EmptyOutput,
+}
+
+impl std::fmt::Display for VersionProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout(secs) => write!(f, "timed out after {}s", secs),
+            Self::Spawn(e) => write!(f, "failed to start: {}", e),
+            Self::Exit { status, stderr } => {
+                write!(f, "exited with {}; stderr: {}", status, stderr)
+            }
+            Self::EmptyOutput => write!(f, "produced no version output"),
+        }
+    }
+}
+
+/// Run a binary with its version flag and return the first output line.
+pub async fn probe_binary_version(
+    binary_path: &Path,
+    version_flag: &str,
+    timeout: Duration,
+) -> Result<String, VersionProbeError> {
     let mut cmd = tokio::process::Command::new(binary_path);
     cmd.arg(version_flag);
+    // A probe that outlives its timeout must not linger as an orphan.
+    cmd.kill_on_drop(true);
 
     #[cfg(target_os = "windows")]
     {
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     }
 
+    let output = tokio::time::timeout(timeout, cmd.output())
+        .await
+        .map_err(|_| VersionProbeError::Timeout(timeout.as_secs()))?
+        .map_err(|e| VersionProbeError::Spawn(format!("{} ({})", e, e.kind())))?;
+
+    if !output.status.success() {
+        return Err(VersionProbeError::Exit {
+            status: output.status.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or(VersionProbeError::EmptyOutput)
+}
+
+/// Get the version string from a binary by running it with a version flag.
+pub async fn get_binary_version(binary_path: &Path, version_flag: &str) -> Option<String> {
     // yt-dlp's onedir build does a one-time PyInstaller bootstrap on its first run
     // (the post-install verification call), measured around 9s on macOS — keep the
     // timeout well above that so a slow cold start isn't misread as a failed install.
-    let output = tokio::time::timeout(std::time::Duration::from_secs(25), cmd.output())
+    probe_binary_version(binary_path, version_flag, Duration::from_secs(25))
         .await
-        .ok()?
-        .ok()?;
+        .ok()
+}
 
-    if output.status.success() {
-        String::from_utf8(output.stdout)
-            .ok()
-            .map(|s| s.lines().next().unwrap_or("").trim().to_string())
-            .filter(|s| !s.is_empty())
-    } else {
-        None
+/// Verify a freshly staged binary before swapping it into place. Retries once on
+/// timeout (cold or loaded machines), but treats spawn errors, non-zero exits,
+/// persistent timeouts, and empty output as a hard failure — an unverifiable
+/// staged copy must never replace a working one.
+pub async fn verify_staged_binary(path: &Path, version_flag: &str) -> Result<String, AppError> {
+    let mut probe = probe_binary_version(path, version_flag, Duration::from_secs(20)).await;
+    if matches!(probe, Err(VersionProbeError::Timeout(_))) {
+        probe = probe_binary_version(path, version_flag, Duration::from_secs(40)).await;
     }
+    probe.map_err(|e| {
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.display().to_string());
+        AppError::DependencyInstallError(format!(
+            "{} installed but failed to run ({}): {}; the download may be corrupt or incompatible",
+            name, version_flag, e
+        ))
+    })
 }
 
 /// Emit a stage event for dependency installation progress.

--- a/src-tauri/src/ytdlp/dep_ffmpeg.rs
+++ b/src-tauri/src/ytdlp/dep_ffmpeg.rs
@@ -167,7 +167,9 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<String, AppError> {
         return Err(e);
     }
 
-    // Extract
+    // Extract into a staging directory, never directly over the live binaries:
+    // File::create would truncate a working ffmpeg first, so an interrupted
+    // extraction (crash, disk full) must land in a disposable location.
     emit_stage(
         app,
         "ffmpeg",
@@ -175,59 +177,105 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<String, AppError> {
         Some("Extracting ffmpeg..."),
     );
 
-    let extracted = match info.format {
-        ArchiveFormat::Zip => extract_zip(&archive_path, &bin_dir, binary_names).await?,
-        ArchiveFormat::TarGz => extract_tar_gz(&archive_path, &bin_dir, binary_names).await?,
-        ArchiveFormat::TarXz => extract_tar_xz(&archive_path, &bin_dir, binary_names).await?,
+    let staging = bin_dir.join("ffmpeg.staging");
+    let _ = std::fs::remove_dir_all(&staging);
+    if let Err(e) = std::fs::create_dir_all(&staging) {
+        let _ = tokio::fs::remove_file(&archive_path).await;
+        return Err(AppError::DependencyInstallError(format!(
+            "Failed to create staging dir: {}",
+            e
+        )));
+    }
+
+    let extract_result = match info.format {
+        ArchiveFormat::Zip => extract_zip(&archive_path, &staging, binary_names).await,
+        ArchiveFormat::TarGz => extract_tar_gz(&archive_path, &staging, binary_names).await,
+        ArchiveFormat::TarXz => extract_tar_xz(&archive_path, &staging, binary_names).await,
+    };
+    // The archive is no longer needed whether or not extraction worked.
+    let _ = tokio::fs::remove_file(&archive_path).await;
+    let extracted = match extract_result {
+        Ok(files) => files,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e);
+        }
     };
 
-    if extracted.is_empty() {
-        // Clean up archive
-        let _ = tokio::fs::remove_file(&archive_path).await;
-        return Err(AppError::DependencyInstallError(
-            "ffmpeg binary not found in archive".to_string(),
-        ));
-    }
-
-    // Set executable + remove quarantine for each extracted binary
-    for path in &extracted {
-        set_executable(path)?;
-        remove_quarantine(path)?;
-    }
-
-    // Clean up archive
-    let _ = tokio::fs::remove_file(&archive_path).await;
-
-    // Verify installation
-    emit_stage(
-        app,
-        "ffmpeg",
-        DepInstallStage::Completing,
-        Some("Verifying installation..."),
-    );
     let ffmpeg_bin = if cfg!(target_os = "windows") {
         "ffmpeg.exe"
     } else {
         "ffmpeg"
     };
-    let ffmpeg_path = bin_dir.join(ffmpeg_bin);
-    // The archive checksum was verified above when one was available. A successful
-    // `ffmpeg -version` is the final sanity gate (and the only integrity check when the
-    // checksum couldn't be fetched). If the extracted binary does not run, treat the
-    // install as failed and remove the broken binaries so a later dependency check does
-    // not report them as installed.
-    let version = match get_binary_version(&ffmpeg_path, "-version").await {
-        Some(v) => v,
-        None => {
-            for path in &extracted {
-                let _ = tokio::fs::remove_file(path).await;
-            }
-            return Err(AppError::DependencyInstallError(
-                "ffmpeg installed but failed to run (-version); the download may be corrupt"
-                    .to_string(),
-            ));
+    let staged_ffmpeg = staging.join(ffmpeg_bin);
+    if !staged_ffmpeg.exists() {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(AppError::DependencyInstallError(
+            "ffmpeg binary not found in archive".to_string(),
+        ));
+    }
+
+    // Executable bit + quarantine strip happen on the STAGED files, before the
+    // version probe (which needs to run them) and the swap.
+    for path in &extracted {
+        if let Err(e) = set_executable(path) {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e);
         }
+        let _ = remove_quarantine(path);
+    }
+
+    // The archive checksum was verified above when one was available. A successful
+    // `-version` run of every staged binary is the final sanity gate (and the only
+    // integrity check when the checksum couldn't be fetched). Both ffmpeg and
+    // ffprobe must pass BEFORE anything is swapped in, so a half-working pair can
+    // never replace a fully working one.
+    emit_stage(
+        app,
+        "ffmpeg",
+        DepInstallStage::Verifying,
+        Some("Verifying installation..."),
+    );
+    let fail_verify = |e: AppError| {
+        let _ = std::fs::remove_dir_all(&staging);
+        emit_stage(app, "ffmpeg", DepInstallStage::Failed, Some(&e.to_string()));
+        e
     };
+    let version = verify_staged_binary(&staged_ffmpeg, "-version")
+        .await
+        .map_err(&fail_verify)?;
+    for path in extracted.iter().filter(|p| **p != staged_ffmpeg) {
+        verify_staged_binary(path, "-version")
+            .await
+            .map_err(&fail_verify)?;
+    }
+
+    // Last-moment gate under the dependency lock: never swap binaries while a
+    // download could be mid-merge with the old ffmpeg.
+    if downloads_busy(app) {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(downloads_busy_error());
+    }
+
+    // Swap all binaries back-to-back, only after every probe passed, keeping the
+    // window for a version-mismatched ffmpeg/ffprobe pair as small as possible.
+    // `std::fs::rename` replaces an existing destination (MOVEFILE_REPLACE_EXISTING
+    // on Windows); if the target is locked by a running process the rename fails
+    // and the old, working binary is left untouched.
+    for path in &extracted {
+        let Some(name) = path.file_name() else {
+            continue;
+        };
+        if let Err(e) = std::fs::rename(path, bin_dir.join(name)) {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(AppError::DependencyInstallError(format!(
+                "Failed to install {}: {}",
+                name.to_string_lossy(),
+                e
+            )));
+        }
+    }
+    let _ = std::fs::remove_dir_all(&staging);
 
     emit_stage(
         app,
@@ -244,8 +292,7 @@ pub async fn get_latest_version() -> Result<String, AppError> {
     // BtbN builds use rolling "latest" tag, so we just return a placeholder.
     // For vanloctech/ffmpeg-macos, check the latest release.
     if cfg!(target_os = "macos") {
-        let client = reqwest::Client::new();
-        let resp = client
+        let resp = short_http_client()
             .get("https://api.github.com/repos/vanloctech/ffmpeg-macos/releases/latest")
             .header("User-Agent", "yummy-yt-dlp")
             .send()

--- a/src-tauri/src/ytdlp/dep_ytdlp.rs
+++ b/src-tauri/src/ytdlp/dep_ytdlp.rs
@@ -1,7 +1,9 @@
 use super::dep_download::*;
 use super::types::DepInstallStage;
+use crate::modules::logger;
 use crate::modules::types::AppError;
 use std::path::Path;
+use std::time::Duration;
 use tauri::AppHandle;
 
 /// yt-dlp ships as a PyInstaller `--onedir` zip per platform: the executable plus
@@ -146,6 +148,51 @@ pub async fn install_ytdlp(app: &AppHandle) -> Result<String, AppError> {
     }
     let _ = remove_quarantine_recursive(&staging);
 
+    // Verify the STAGED binary before swapping it in: a failed update must never
+    // destroy the last working tree. Only spawn errors, non-zero exits, and empty
+    // output are fatal — a slow PyInstaller cold start (timeout) gets one retry
+    // with a longer window and then installs with a warning rather than discarding
+    // a build that may simply be slow to bootstrap.
+    emit_stage(
+        app,
+        "yt-dlp",
+        DepInstallStage::Verifying,
+        Some("Verifying installation..."),
+    );
+    let staged_exe = staging.join(get_binary_name());
+    let mut probe = probe_binary_version(&staged_exe, "--version", Duration::from_secs(25)).await;
+    if matches!(probe, Err(VersionProbeError::Timeout(_))) {
+        probe = probe_binary_version(&staged_exe, "--version", Duration::from_secs(60)).await;
+    }
+    let version = match probe {
+        Ok(v) => v,
+        Err(VersionProbeError::Timeout(_)) => {
+            logger::warn_cat(
+                "dependency",
+                "yt-dlp version probe timed out twice; keeping the install (cold start can exceed the probe window)",
+            );
+            "unknown".to_string()
+        }
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&staging);
+            let msg = format!(
+                "yt-dlp installed but failed to run (--version): {}; the download may be corrupt or incompatible",
+                e
+            );
+            emit_stage(app, "yt-dlp", DepInstallStage::Failed, Some(&msg));
+            return Err(AppError::DependencyInstallError(msg));
+        }
+    };
+
+    // Last-moment gate under the dependency lock: never swap the tree while a
+    // download could be running the old yt-dlp. A download started between this
+    // check and the rename can still race (TOCTOU), but this closes the realistic
+    // startup auto-update vs queue-resume collision.
+    if downloads_busy(app) {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(downloads_busy_error());
+    }
+
     let final_dir = ytdlp_dir(&bin_dir);
     if let Err(e) = finalize_dir(&staging, &final_dir) {
         let _ = std::fs::remove_dir_all(&staging);
@@ -153,18 +200,6 @@ pub async fn install_ytdlp(app: &AppHandle) -> Result<String, AppError> {
     }
 
     remove_legacy_binary(&bin_dir);
-
-    // Verify installation
-    emit_stage(
-        app,
-        "yt-dlp",
-        DepInstallStage::Completing,
-        Some("Verifying installation..."),
-    );
-    let final_exe = final_dir.join(get_binary_name());
-    let version = get_binary_version(&final_exe, "--version")
-        .await
-        .unwrap_or_else(|| "unknown".to_string());
 
     emit_stage(
         app,
@@ -178,8 +213,7 @@ pub async fn install_ytdlp(app: &AppHandle) -> Result<String, AppError> {
 
 /// Get the latest yt-dlp version from GitHub API.
 pub async fn get_latest_version() -> Result<String, AppError> {
-    let client = reqwest::Client::new();
-    let resp = client
+    let resp = short_http_client()
         .get("https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest")
         .header("User-Agent", "yummy-yt-dlp")
         .send()


### PR DESCRIPTION
This PR hardens the dependency installer pipeline (yt-dlp / ffmpeg / ffprobe / deno): installs are now staged and swapped atomically instead of truncating live binaries in place, all dependency network I/O is bounded so the per-dependency lock can never wedge the UI on a stalled connection, install success is gated on an actual version probe of the staged binary, binary mutation no longer collides with active or startup-resumed downloads, and orphaned staging/temp artifacts are cleaned up at install start and app startup. Backend-only; no Tauri command/event/type surface changes (`src/lib/bindings.ts` untouched).

## Fixes

- **Staged, probe-verified installs for ffmpeg/ffprobe/deno** (`src-tauri/src/ytdlp/dep_ffmpeg.rs`, `src-tauri/src/ytdlp/dep_deno.rs`, `src-tauri/src/ytdlp/dep_download.rs`) — archives now extract into per-dependency staging directories (`bin/ffmpeg.staging`, `bin/deno.staging`); the staged binaries get exec bit/quarantine handling and must pass a version probe before being renamed over the live ones, with ffmpeg+ffprobe swapped back-to-back only after both probes pass, so an interrupted or failed install can no longer leave a truncated or version-mismatched binary that silently breaks every merge step. (deps-install#0)
- **Network timeouts on all dependency HTTP and the unbounded `yt-dlp --update` spawn** (`src-tauri/src/ytdlp/dep_download.rs`, `src-tauri/src/ytdlp/dep_ytdlp.rs`, `src-tauri/src/ytdlp/dep_deno.rs`, `src-tauri/src/ytdlp/binary/resolve.rs`) — shared reqwest clients with connect/read (idle) timeouts for archive downloads and short total timeouts for checksum/version fetches, plus a 5-minute bound on the system-PATH `yt-dlp --update` spawn; a network stall now fails the install with a clear error and releases the per-dependency lock instead of leaving "Installing..." spinning forever with retry/delete deadlocked until app restart. (deps-install#1)
- **Broken binaries no longer reported as installed or handed to downloads** (`src-tauri/src/ytdlp/binary/dep_check.rs`, `src-tauri/src/ytdlp/binary/resolve.rs`) — the dependency check now distinguishes hard probe failures (spawn error, non-zero exit, empty output) from transient timeouts: hard-broken ffmpeg/deno report `installed: false` while keeping path/`app_available` so the UI can offer reinstall, `choose_dep` skips broken candidates in favor of a working system copy, and the ffmpeg resolver skips a known-broken app-managed binary (probe marker reset by `invalidate_dep_cache` so a fresh install reflects immediately), so users no longer see a green check next to a binary that fails every download. (deps-install#2)
- **Dependency updates are gated on download activity** (`src-tauri/src/ytdlp/dep_autoupdate.rs`, `src-tauri/src/ytdlp/dep_ytdlp.rs`, `src-tauri/src/ytdlp/dep_ffmpeg.rs`, `src-tauri/src/ytdlp/dep_deno.rs`) — the startup auto-updater checks both `DownloadManager::active_count()` and pending/downloading queue rows (covering the 300ms-delayed startup resume) and skips while rewinding the 24h throttle stamp so the next launch retries; each installer re-checks busyness immediately before its mutating step under the per-dependency lock and returns a clear "cannot update while downloads are running" error through the existing Result channel, eliminating the launch-time self-collision that failed in-flight downloads with confusing "yt-dlp not found"/postprocessing errors. (download-lifecycle#8, deps-install#3)
- **Install success requires the binary to actually run** (`src-tauri/src/ytdlp/dep_ytdlp.rs`, `src-tauri/src/ytdlp/dep_deno.rs`, `src-tauri/src/ytdlp/dep_download.rs`) — a new internal `probe_binary_version` distinguishes timeout from spawn-error/non-zero-exit/empty-output and carries exit code/stderr into the error; yt-dlp is verified on the staging exe *before* `finalize_dir` so a failed update never destroys the last working tree (with lenient double-timeout handling for PyInstaller cold start), deno's `unwrap_or("unknown")` is tightened the same way, and the pre-verification progress event was moved from `Completing` to `Verifying` so the frontend's optimistic "installed" state only fires after verification passes, ending silent "installed but cannot run" successes. (deps-install#4)
- **Orphaned downloads/staging artifacts are cleaned up** (`src-tauri/src/ytdlp/dep_download.rs`, `src-tauri/src/ytdlp/dep_ffmpeg.rs`, `src-tauri/src/ytdlp/dep_deno.rs`, `src-tauri/src/ytdlp/commands/dependency.rs`, `src-tauri/src/lib.rs`) — `download_file` drops the file handle before removing the partial temp file on every error path (Windows-safe, including the flush error), archives are deleted immediately after extraction regardless of result, `delete_app_managed_dep` now also removes `ytdlp.old`/`ytdlp.staging`/temp archives/staging dirs, and a one-time startup sweep in `lib.rs` (placed next to `seed_bundled_binaries`, outside the per-dep-concurrent `ensure_bin_dir` path) clears leftovers, so repeated failed installs no longer accumulate hundreds of MB of invisible junk. (deps-install#7)

Also applied while editing these files: `kill_on_drop(true)` on all timeout-wrapped probe `.output()` calls in `binary/resolve.rs` and `binary/dep_check.rs` (deliberately left out of the process-leaks PR to avoid file overlap).

### Known residual races (accepted by design)

- The busy gate is TOCTOU-racy: a download claimed between the busy check and the rename/finalize step can still collide with the swap. This is the accepted pragmatic fix — a complete exclusion would require installers and executors to share a lock, which is out of scope here.
- If the ffmpeg rename succeeds but the immediately following ffprobe rename fails (target locked), a mismatched pair is possible in that tiny window; back-to-back renames after dual probes were chosen over a heavier backup/restore scheme.

## Verification

- `cargo fmt` — clean
- `cargo clippy -- -D warnings` — no warnings
- `cargo test` — 79 tests passed
- `bun run check` (svelte-check) — no errors
- `bun run build` (vite build) — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
